### PR TITLE
Add methods for accessing Widget Root

### DIFF
--- a/modules/contentbox-ui/interceptors/CBRequest.cfc
+++ b/modules/contentbox-ui/interceptors/CBRequest.cfc
@@ -7,7 +7,7 @@ component extends="coldbox.system.Interceptor"{
 
 	/**
 	* Configure CB Request
-	*/ 
+	*/
 	function configure(){}
 
 	/**
@@ -16,8 +16,8 @@ component extends="coldbox.system.Interceptor"{
 	function preProcess(event, interceptData) eventPattern="^contentbox-ui"{
 		var prc = event.getCollection(private=true);
 		var rc	= event.getCollection();
-		
-		// store module root	
+
+		// store module root
 		prc.cbRoot = event.getModuleRoot();
 		// store module entry point
 		prc.cbEntryPoint = getProperty("entryPoint");
@@ -29,21 +29,23 @@ component extends="coldbox.system.Interceptor"{
 		prc.cbLayout = prc.cbSettings.cb_site_layout;
 		// Place layout root location
 		prc.cbLayoutRoot = prc.cbRoot & "/layouts/" & prc.cbLayout;
+		// Place widget root location
+		prc.cbWidgetRoot = prc.cbRoot & "/plugins/widgets";
 		// announce event
-		announceInterception("cbui_preRequest");	
-	}	
-	
+		announceInterception("cbui_preRequest");
+	}
+
 	/**
 	* Fired on contentbox requests
 	*/
 	function postProcess(event, interceptData) eventPattern="^contentbox-ui"{
 		var prc = event.getCollection(private=true);
 		var rc	= event.getCollection();
-		
+
 		// announce event
-		announceInterception("cbui_postRequest");	
-	}	
-	
+		announceInterception("cbui_postRequest");
+	}
+
 	/*
 	* Renderer helper injection
 	*/
@@ -51,7 +53,7 @@ component extends="coldbox.system.Interceptor"{
 		var prc = event.getCollection(private=true);
 		// Only for contentbox-ui
 		if( !event.getCurrentModule() eq "contentbox-ui" ){ return; }
-		
+
 		// check for renderer
 		if( isInstanceOf(arguments.interceptData.oPlugin,"coldbox.system.plugins.Renderer") ){
 			// decorate it
@@ -59,15 +61,15 @@ component extends="coldbox.system.Interceptor"{
 			arguments.interceptData.oPlugin.$cbInject = variables.$cbInject;
 			arguments.interceptData.oPlugin.$cbInject();
 			// announce event
-			announceInterception("cbui_onRendererDecoration",{renderer=arguments.interceptData.oPlugin,CBHelper=arguments.interceptData.oPlugin.cb});	
-		}		
+			announceInterception("cbui_onRendererDecoration",{renderer=arguments.interceptData.oPlugin,CBHelper=arguments.interceptData.oPlugin.cb});
+		}
 	}
-	
+
 	/**
 	* private inject
 	*/
 	function $cbinject(){
 		variables.cb = this.cb;
 	}
-				
+
 }

--- a/modules/contentbox/plugins/CBHelper.cfc
+++ b/modules/contentbox/plugins/CBHelper.cfc
@@ -73,6 +73,12 @@ component extends="coldbox.system.Plugin" accessors="true" singleton{
 		return prc.cbLayout;
 	}
 
+	// Get the location of the widgets in the application, great for assets, cfincludes, etc
+	function widgetRoot(){
+		var prc = getRequestCollection(private=true);
+		return prc.cbWidgetRoot;
+	}
+
 	/************************************** site properties *********************************************/
 
 	// Retrieve the site name
@@ -225,7 +231,7 @@ component extends="coldbox.system.Plugin" accessors="true" singleton{
 		if ( isEntryView() ){
 			return linkEntry( getCurrentEntry() );
 		}
-	
+
 		return linkPage( getCurrentPage() );
 	}
 


### PR DESCRIPTION
Added widgetRoot() to cbHelper Plugin and prc.cbWidgetRoot to CBRequest for easy assets from a widget
