### PR TITLE
Fix for links to media items chosen from ckeditor link dialog

### DIFF
--- a/modules/contentbox-filebrowser/includes/javascript/fbSelectCallbacks.js
+++ b/modules/contentbox-filebrowser/includes/javascript/fbSelectCallbacks.js
@@ -16,6 +16,10 @@
 function fbCKSelect(sPath,sURL,sType){
 	if( !sPath.length || sType == "dir" ){ alert("Please select a file first."); return; }
 	var funcNum = getUrlParam('CKEditorFuncNum');
+	var dialog = window.opener.CKEDITOR.dialog.getCurrent();
+	var protocol = dialog.getContentElement( 'info', 'protocol' );
+	if( protocol ) dialog.setValueOf('info', 'protocol', '');
+	
 	window.opener.CKEDITOR.tools.callFunction(funcNum, sURL);
 	window.close();
 }


### PR DESCRIPTION
Updated the callback to set the protocol to other when selecting a local media file for the link. This keeps the correct relative link to working correctly.
