### PR TITLE
CONTENTBOX-56: Updated dashboard to order by modified date

### DIFF
--- a/modules/contentbox-admin/handlers/dashboard.cfc
+++ b/modules/contentbox-admin/handlers/dashboard.cfc
@@ -27,7 +27,7 @@ component extends="baseHandler"{
 		prc.tabDashboard_home = true;
 
 		// Get entries viewlet: Stupid cf9 and its local scope blown on argument literals
-		var eArgs = {max=prc.cbSettings.cb_dashboard_recentEntries,pagination=false};
+		var eArgs = {max=prc.cbSettings.cb_dashboard_recentEntries,pagination=false, latest=true};
 		prc.entriesViewlet = runEvent(event="contentbox-admin:entries.pager",eventArguments=eArgs);
 		// Get Pages viewlet
 		var eArgs = {max=prc.cbSettings.cb_dashboard_recentPages,pagination=false, latest=true, sorting=false};

--- a/modules/contentbox-admin/handlers/entries.cfc
+++ b/modules/contentbox-admin/handlers/entries.cfc
@@ -274,7 +274,7 @@ component extends="baseHandler"{
 	}
 
 	// pager viewlet
-	function pager(event,rc,prc,authorID="all",max=0,pagination=true){
+	function pager(event,rc,prc,authorID="all",max=0,pagination=true,latest=false){
 
 		// check if authorID exists in rc to do an override, maybe it's the paging call
 		if( event.valueExists("pager_authorID") ){
@@ -297,11 +297,16 @@ component extends="baseHandler"{
 		prc.pager_paging 	  	= prc.pager_pagingPlugin.getBoundaries();
 		prc.pager_pagingLink 	= "javascript:pagerLink(@page@)";
 		prc.pager_pagination	= arguments.pagination;
-
+		
+		// Sorting
+		var sortOrder = "publishedDate DESC";
+		if( arguments.latest ){ sortOrder = "modifiedDate desc"; }
+		
 		// search entries with filters and all
 		var entryResults = entryService.search(author=arguments.authorID,
 											   offset=prc.pager_paging.startRow-1,
-											   max=arguments.max);
+											   max=arguments.max,
+											   sortOrder=sortOrder);
 		prc.pager_entries 	    = entryResults.entries;
 		prc.pager_entriesCount  = entryResults.count;
 

--- a/modules/contentbox-admin/handlers/pages.cfc
+++ b/modules/contentbox-admin/handlers/pages.cfc
@@ -410,7 +410,7 @@ component extends="baseHandler"{
 
 		// Sorting
 		var sortOrder = "title asc";
-		if( arguments.latest ){ sortOrder = "publishedDate desc"; }
+		if( arguments.latest ){ sortOrder = "modifiedDate desc"; }
 
 		// search entries with filters and all
 		var pageResults = pageService.search(author=arguments.authorID,

--- a/modules/contentbox/model/content/PageService.cfc
+++ b/modules/contentbox/model/content/PageService.cfc
@@ -74,20 +74,30 @@ component extends="ContentService" singleton{
 		var results = {};
 		// criteria queries
 		var c = newCriteria();
-
+		// stub out activeContent alias based on potential conditions...
+		// this way, we don't have to worry about accidentally creating it twice, or not creating it at all
+		if(
+			( structKeyExists(arguments,"author") AND arguments.author NEQ "all" ) ||
+			( len(arguments.search) ) ||
+			( findNoCase( "modifiedDate", arguments.sortOrder ) )
+		) {
+			c.createAlias( "activeContent", "ac" );
+		}
+		// create sort order for aliased property
+		if( findNoCase( "modifiedDate", arguments.sortOrder ) ) {
+			sortOrder = replaceNoCase( arguments.sortOrder, "modifiedDate", "ac.createdDate" );
+		}
 		// isPublished filter
 		if( structKeyExists(arguments,"isPublished") AND arguments.isPublished NEQ "any"){
 			c.eq("isPublished", javaCast("boolean",arguments.isPublished));
 		}
 		// Author Filter
 		if( structKeyExists(arguments,"author") AND arguments.author NEQ "all"){
-			c.createAlias("activeContent","ac")
-				.isEq("ac.author.authorID", javaCast("int",arguments.author) );
+			c.isEq("ac.author.authorID", javaCast("int",arguments.author) );
 		}
 		// Search Criteria	
 		if( len(arguments.search) ){
 			// like disjunctions
-			c.createAlias("activeContent","ac");
 			c.or( c.restrictions.like("title","%#arguments.search#%"),
 				  c.restrictions.like("ac.content", "%#arguments.search#%") );
 		}


### PR DESCRIPTION
Updated search() methods in PageService and EntryService to allow for
sorting by last modified date (createdDate on ActiveContent). This is
now the default for the dashboard to give a more real-time indication
of activity on pages and blog posts.
