### PR TITLE
CONTENTBOX-68: JS Updates to Close info/action panels on body click

### DIFF
--- a/modules/contentbox-admin/views/entries/index.cfm
+++ b/modules/contentbox-admin/views/entries/index.cfm
@@ -180,7 +180,7 @@
 						<td class="center">#entry.getNumberOfComments()#</td>
 						<td class="center">
 							<!---Info Panel --->
-							<button class="button" onclick="return toggleInfoPanel('#entry.getContentID()#')" title="Entry Info" ><img src="#prc.cbroot#/includes/images/gravatar.png" /></button>
+							<button class="button infoPanelButton" title="Entry Info" ><img src="#prc.cbroot#/includes/images/gravatar.png" /></button>
 							<!---Info Panel --->
 							<div id="infoPanel_#entry.getContentID()#" class="contentInfoPanel">
 								<img src="#prc.cbRoot#/includes/images/calendar_small.png" alt="calendar"/>  
@@ -203,7 +203,7 @@
 							</div>
 							
 							<!---Entry Actions --->
-							<button class="button" onclick="return toggleActionsPanel('#entry.getContentID()#')" title="Entry Actions" ><img src="#prc.cbroot#/includes/images/settings_black.png" /></button>
+							<button class="button actionsPanelButton" title="Entry Actions" ><img src="#prc.cbroot#/includes/images/settings_black.png" /></button>
 							<!---Entry Actions Panel --->
 							<div id="entryActions_#entry.getContentID()#" class="actionsPanel">
 								<cfif prc.oAuthor.checkPermission("ENTRIES_EDITOR") OR prc.oAuthor.checkPermission("ENTRIES_ADMIN")>

--- a/modules/contentbox-admin/views/entries/indexHelper.cfm
+++ b/modules/contentbox-admin/views/entries/indexHelper.cfm
@@ -18,14 +18,86 @@ $(document).ready(function() {
 			}
 	    }
 	});
-
+    // add click listener to info panel buttons
+    $( '.infoPanelButton' ).click( function( e ){
+        handlePanelClick( e, this, '.contentInfoPanel', '.actionsPanel', toggleInfoPanel );
+    });
+    // add click listener to actions panel buttons
+    $( '.actionsPanelButton' ).click( function( e ){
+        handlePanelClick( e, this, '.actionsPanel', '.contentInfoPanel', toggleActionsPanel );
+    });
+    // add click listener to body to hide info and action panels
+    $( 'body' ).click( function( e ){
+       var target = $( e.target ),
+           ipIgnore = [],
+           apIgnore = [],
+           ipTarget = target.closest( '.contentInfoPanel' ),
+           apTarget = target.closest( '.actionsPanel' )
+       // if click occurs within visible element, add to ignore list
+       if( ipTarget.length ) {
+           ipIgnore.push( ipTarget[ 0 ].id );
+       }
+       // hideInfoPanels( ipIgnore );
+       if( apTarget.length ) {
+           apIgnore.push( apTarget[ 0 ].id );
+       }
+       // run global hide methods
+       hidePanels( '.contentInfoPanel', ipIgnore );
+       hidePanels( '.actionsPanel', apIgnore );
+    });
 });
+/*
+ * Consolidated way to show selected panel and hide others
+ * @e {Event} the click event
+ * @el {HTMLElement} the button which was clicked
+ * @selector {String} the selector class of the target element
+ * @antiselector {String} the selector class of hideable elements
+ * @handler {Function} the function to execute
+ */
+function handlePanelClick( e, el, selector, antiselector, handler ) {
+    // prevent default event
+    e.preventDefault();
+    // stop propagation so click doesn't bubble to body
+    e.stopPropagation();
+    var button = $( el ),
+        row = button.closest( 'tr' ),
+        childPanel = row.find( selector ),
+        contentID = row.attr( 'data-contentID' );
+    // if we find a contentID, toggle that panel
+    if( contentID != null ) {
+        handler.call( this, contentID );
+        //toggleActionsPanel( contentID );
+        // hide other panels
+        hidePanels( selector, [ childPanel[ 0 ].id ] );
+        hidePanels( antiselector );
+    }
+}
+/*
+ * Hides panels which match the passed selector
+ * @selector {String} the selector class of panels to hide
+ * @ignore {Array} array of ids of elements to ignore when hiding elements
+ */
+function hidePanels( selector, ignore ) {
+    var ignore = !ignore ? [] : ignore;
+    $( selector ).each(function() {
+        var me = this;
+        if( $.inArray( me.id, ignore )==-1 ) {
+            $( this ).slideUp({
+                duration: 200
+            })
+        }
+    });
+}
 function toggleActionsPanel(contentID){
-	$("##entryActions_" + contentID).slideToggle();
+	$("##entryActions_" + contentID).slideToggle({
+        duration:200
+    });
 	return false;
 }
 function toggleInfoPanel(contentID){
-	$("##infoPanel_" + contentID).slideToggle();
+	$("##infoPanel_" + contentID).slideToggle({
+        duration:200
+    });
 	return false;
 }
 function remove(contentID){

--- a/modules/contentbox-admin/views/pages/index.cfm
+++ b/modules/contentbox-admin/views/pages/index.cfm
@@ -207,7 +207,7 @@
 						<td class="center">#page.getHits()#</td>
 						<td class="center">
 							<!---Info Panel --->
-							<button class="button" onclick="return toggleInfoPanel('#page.getContentID()#')" title="Page Info" ><img src="#prc.cbroot#/includes/images/gravatar.png" /></button>
+							<button class="button infoPanelButton" title="Page Info" ><img src="#prc.cbroot#/includes/images/gravatar.png" /></button>
 							<!---Info Panel --->
 							<div id="infoPanel_#page.getContentID()#" class="contentInfoPanel">
 								<img src="#prc.cbRoot#/includes/images/calendar_small.png" alt="calendar"/>  
@@ -235,7 +235,7 @@
 							</div>
 							
 							<!---Page Actions --->
-							<button class="button" onclick="return toggleActionsPanel('#page.getContentID()#')" title="Page Actions" ><img src="#prc.cbroot#/includes/images/settings_black.png" /></button>
+							<button class="button actionsPanelButton" title="Page Actions" ><img src="#prc.cbroot#/includes/images/settings_black.png" /></button>
 							<!---Page Actions Panel --->
 							<div id="pageActions_#page.getContentID()#" class="actionsPanel">
 								<cfif prc.oAuthor.checkPermission("PAGES_EDITOR") OR prc.oAuthor.checkPermission("PAGES_ADMIN")>

--- a/modules/contentbox-admin/views/pages/indexHelper.cfm
+++ b/modules/contentbox-admin/views/pages/indexHelper.cfm
@@ -41,13 +41,86 @@ $(document).ready(function() {
 		}
 	});
 	</cfif>
+    // add click listener to info panel buttons
+    $( '.infoPanelButton' ).click( function( e ){
+        handlePanelClick( e, this, '.contentInfoPanel', '.actionsPanel', toggleInfoPanel );
+    });
+    // add click listener to actions panel buttons
+    $( '.actionsPanelButton' ).click( function( e ){
+        handlePanelClick( e, this, '.actionsPanel', '.contentInfoPanel', toggleActionsPanel );
+    });
+    // add click listener to body to hide info and action panels
+    $( 'body' ).click( function( e ){
+       var target = $( e.target ),
+           ipIgnore = [],
+           apIgnore = [],
+           ipTarget = target.closest( '.contentInfoPanel' ),
+           apTarget = target.closest( '.actionsPanel' )
+       // if click occurs within visible element, add to ignore list
+       if( ipTarget.length ) {
+           ipIgnore.push( ipTarget[ 0 ].id );
+       }
+       // hideInfoPanels( ipIgnore );
+       if( apTarget.length ) {
+           apIgnore.push( apTarget[ 0 ].id );
+       }
+       // run global hide methods
+       hidePanels( '.contentInfoPanel', ipIgnore );
+       hidePanels( '.actionsPanel', apIgnore );
+    });
 });
+/*
+ * Consolidated way to show selected panel and hide others
+ * @e {Event} the click event
+ * @el {HTMLElement} the button which was clicked
+ * @selector {String} the selector class of the target element
+ * @antiselector {String} the selector class of hideable elements
+ * @handler {Function} the function to execute
+ */
+function handlePanelClick( e, el, selector, antiselector, handler ) {
+    // prevent default event
+    e.preventDefault();
+    // stop propagation so click doesn't bubble to body
+    e.stopPropagation();
+    var button = $( el ),
+        row = button.closest( 'tr' ),
+        childPanel = row.find( selector ),
+        contentID = row.attr( 'data-contentID' );
+    // if we find a contentID, toggle that panel
+    if( contentID != null ) {
+        handler.call( this, contentID );
+        //toggleActionsPanel( contentID );
+        // hide other panels
+        hidePanels( selector, [ childPanel[ 0 ].id ] );
+        hidePanels( antiselector );
+    }
+}
+/*
+ * Hides panels which match the passed selector
+ * @selector {String} the selector class of panels to hide
+ * @ignore {Array} array of ids of elements to ignore when hiding elements
+ */
+function hidePanels( selector, ignore ) {
+    var ignore = !ignore ? [] : ignore;
+    $( selector ).each(function() {
+        var me = this;
+        if( $.inArray( me.id, ignore )==-1 ) {
+            $( this ).slideUp({
+                duration: 200
+            })
+        }
+    });
+}
 function toggleActionsPanel(contentID){
-	$("##pageActions_" + contentID).slideToggle();
+	$("##pageActions_" + contentID).slideToggle({
+        duration:200
+    });
 	return false;
 }
 function toggleInfoPanel(contentID){
-	$("##infoPanel_" + contentID).slideToggle();
+	$("##infoPanel_" + contentID).slideToggle({
+        duration:200
+    });
 	return false;
 }
 function remove(contentID){


### PR DESCRIPTION
- Removed onclicks from buttons and implemented a selector-based event
  handler in helpers
- Added body onclick to hide open panels
