### PR TITLE
CONTENTBOX-157: Switch to Category modal add/edit

### DIFF
--- a/modules/contentbox-admin/includes/js/contentbox.js
+++ b/modules/contentbox-admin/includes/js/contentbox.js
@@ -59,7 +59,33 @@ $(document).ready(function() {
             error.appendTo( element.parent("div.controls") );
         }
     })	
-	
+    
+    // simple method to blank out all form fields 
+    $.fn.clearForm = function() {
+        // reset classes and what not
+        this.data( 'validator' ).resetForm();
+        // run over input fields and blank them out
+        this.find(':input').each(function() {
+            switch(this.type) {
+                case 'password':
+                case 'hidden':
+                case 'select-multiple':
+                case 'select-one':
+                case 'text':
+                case 'textarea':
+                    $(this).val('');
+                    break;
+                case 'checkbox':
+                case 'radio':
+                    this.checked = false;
+            }
+        });
+        // also remove success and error classes
+        this.find( '.control-group' ).each(function() {
+            $( this ).removeClass( 'error' ).removeClass( 'success' );
+        });
+    }
+    
 	// flicker messages
 	var t=setTimeout("toggleFlickers()",5000);
 });
@@ -145,12 +171,16 @@ function toggleFlickers(){
 	$(".cbox_messagebox_warn").slideToggle();
 	$(".cbox_messagebox_error").slideToggle();
 }
+
 /**
  * A-la-Carte closing of remote modal windows
  * @return
  */
 function closeRemoteModal(){
-    $(".error").hide();
+    var frm = div.find( 'form' );
+    if( frm.length ) {
+        $( frm[0] ).clearForm();        
+    }
     $remoteModal.modal( 'hide' );
 }
 /**
@@ -158,7 +188,10 @@ function closeRemoteModal(){
 * @param div The jquery div object that represents the dialog.
 */
 function closeModal(div){
-    $(".error").hide();
+    var frm = div.find( 'form' );
+    if( frm.length ) {
+        $( frm[0] ).clearForm();        
+    }
 	div.modal( 'hide' );
 }
 /**
@@ -173,6 +206,15 @@ function openModal(div, w, h){
         width: w,
         height: h
     })
+    // attach a listener to clear form when modal closes
+    $( div ).on( 'hidden', function() {
+        if( !$( this ).hasClass( 'in' ) ) {
+            var frm = $( this ).find( 'form' );
+            if( frm.length ) {
+                $( frm[0] ).clearForm();        
+            }
+        }
+    });
 }
 /**
  * Open a new remote modal window Ajax style.

--- a/modules/contentbox-admin/views/categories/index.cfm
+++ b/modules/contentbox-admin/views/categories/index.cfm
@@ -1,90 +1,92 @@
 ﻿<cfoutput>
-<div class="row-fluid">
-	<!--- main content --->
-	<div class="span9" id="main-content">
-		<div class="box">
-			<!--- Body Header --->
-			<div class="header">
-				<i class="icon-tags icon-large"></i>
-				Content Categories
-			</div>
-			<!--- Body --->
-			<div class="body">
-				
-				<!--- MessageBox --->
-				#getPlugin("MessageBox").renderit()#
-				
-				<!--- CategoryForm --->
-				#html.startForm(name="categoryForm",action=prc.xehCategoryRemove,class="form-vertical")#
-				<input type="hidden" name="categoryID" id="categoryID" value="" />
-				
-				<!--- Content Bar --->
-				<div class="well well-small">
-					<!--- Filter Bar --->
-					<div class="filterBar">
-						<div>
-							#html.textField(name="categoryFilter",size="30",class="textfield",label="Quick Filter:")#
-						</div>
+<div class="row-fluid" id="main-content">
+	<div class="box">
+		<!--- Body Header --->
+		<div class="header">
+			<i class="icon-tags icon-large"></i>
+			Content Categories
+		</div>
+		<!--- Body --->
+		<div class="body">
+			
+			<!--- MessageBox --->
+			#getPlugin("MessageBox").renderit()#
+			
+			<!--- CategoryForm --->
+			#html.startForm(name="categoryForm",action=prc.xehCategoryRemove,class="form-vertical")#
+			<input type="hidden" name="categoryID" id="categoryID" value="" />
+			
+			<!--- Content Bar --->
+			<div class="well well-small">
+			    <!--- Command Bar --->
+				<div class="pull-right">
+					<a href="##" onclick="return createCategory();" class="btn btn-danger">Create Category</a>
+				</div>
+				<!--- Filter Bar --->
+				<div class="filterBar">
+					<div>
+						#html.textField(name="categoryFilter",size="30",class="textfield",label="Quick Filter:")#
 					</div>
 				</div>
-				
-				<!--- categories --->
-				<table name="categories" id="categories" class="tablesorter table table-striped table-hover" width="98%">
-					<thead>
-						<tr>
-							<th>Category Name</th>
-							<th>Slug</th>		
-							<th width="75" class="center">Pages</th>
-							<th width="75" class="center">Entries</th>	
-							<th width="75" class="center {sorter:false}">Actions</th>
-						</tr>
-					</thead>				
-					<tbody>
-						<cfloop array="#prc.categories#" index="category">
-						<tr>
-							<td><a href="javascript:edit('#category.getCategoryID()#','#category.getCategory()#','#category.getSlug()#')" title="Edit #category.getCategory()#">#category.getCategory()#</a></td>
-							<td>#category.getSlug()#</td>
-							<td class="center"><span class="badge badge-info">#category.getNumberOfPages()#</span></td>
-							<td class="center"><span class="badge badge-info">#category.getnumberOfEntries()#</span></td>
-							<td class="center">
-								<cfif prc.oAuthor.checkPermission("CATEGORIES_ADMIN")>
-								<!--- Edit Command --->
-								<a href="javascript:edit('#category.getCategoryID()#','#category.getCategory()#','#category.getSlug()#')" title="Edit #category.getCategory()#"><i class="icon-edit icon-large"></i></a>
-								<!--- Delete Command --->
-								<a title="Delete Category" href="javascript:remove('#category.getcategoryID()#')" class="confirmIt" data-title="Delete Category?"><i class="icon-remove-sign icon-large" id="delete_#category.getCategoryID()#"></i></a>
-								</cfif>
-							</td>
-						</tr>
-						</cfloop>
-					</tbody>
-				</table>
-				#html.endForm()#
+			</div>
 			
-			</div>	
-		</div>
-	</div>
-
-	<!--- main sidebar --->
-	<div class="span3" id="main-sidebar">
-		<!--- Editor Box --->
-		<cfif prc.oAuthor.checkPermission("CATEGORIES_ADMIN")>
-		<div class="small_box">
-			<div class="header">
-				<i class="icon-edit"></i> Editor
-			</div>
-			<div class="body">
-				<!--- Create/Edit form --->
-				#html.startForm(action=prc.xehCategoriesSave,name="categoryEditor",novalidate="novalidate",class="form-vertical")#
-					#html.hiddenField(name="categoryID",value="")#
-					#html.textField(name="category",label="Category:",required="required",maxlength="100",size="30",class="input-block-level",wrapper="div class=controls",labelClass="control-label",groupWrapper="div class=control-group")#
-					#html.textField(name="slug",label="Slug (blank to generate it):",maxlength="100",size="30",class="input-block-level",wrapper="div class=controls",labelClass="control-label",groupWrapper="div class=control-group")#
-					#html.resetButton(name="btnReset",value="Reset Form",class="btn")#
-					#html.submitButton(value="Save Category",class="btn btn-danger")#
-					
-				#html.endForm()#
-			</div>
-		</div>		
-		</cfif>
+			<!--- categories --->
+			<table name="categories" id="categories" class="tablesorter table table-striped table-hover" width="98%">
+				<thead>
+					<tr>
+						<th>Category Name</th>
+						<th>Slug</th>		
+						<th width="75" class="center">Pages</th>
+						<th width="75" class="center">Entries</th>	
+						<th width="75" class="center {sorter:false}">Actions</th>
+					</tr>
+				</thead>				
+				<tbody>
+					<cfloop array="#prc.categories#" index="category">
+					<tr>
+						<td><a href="javascript:edit('#category.getCategoryID()#','#category.getCategory()#','#category.getSlug()#')" title="Edit #category.getCategory()#">#category.getCategory()#</a></td>
+						<td>#category.getSlug()#</td>
+						<td class="center"><span class="badge badge-info">#category.getNumberOfPages()#</span></td>
+						<td class="center"><span class="badge badge-info">#category.getnumberOfEntries()#</span></td>
+						<td class="center">
+							<cfif prc.oAuthor.checkPermission("CATEGORIES_ADMIN")>
+							<!--- Edit Command --->
+							<a href="javascript:edit('#category.getCategoryID()#','#category.getCategory()#','#category.getSlug()#')" title="Edit #category.getCategory()#"><i class="icon-edit icon-large"></i></a>
+							<!--- Delete Command --->
+							<a title="Delete Category" href="javascript:remove('#category.getcategoryID()#')" class="confirmIt" data-title="Delete Category?"><i class="icon-remove-sign icon-large" id="delete_#category.getCategoryID()#"></i></a>
+							</cfif>
+						</td>
+					</tr>
+					</cfloop>
+				</tbody>
+			</table>
+			#html.endForm()#
+		
+		</div>	
 	</div>
 </div>
+<cfif prc.oAuthor.checkPermission("CATEGORIES_ADMIN")>
+<!--- Category Editor --->
+<div id="categoryEditorContainer" class="modal hide fade">
+	<div id="modalContent">
+	<div class="modal-header">
+		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<h3><i class="icon-edit"></i> Editor</h3>
+    </div>
+	<!--- Create/Edit form --->
+	#html.startForm(action=prc.xehCategoriesSave,name="categoryEditor",novalidate="novalidate",class="form-vertical")#
+	<div class="modal-body">
+		#html.hiddenField(name="categoryID",value="")#
+		#html.textField(name="category",label="Category:",required="required",maxlength="100",size="30",class="input-block-level",wrapper="div class=controls",labelClass="control-label",groupWrapper="div class=control-group")#
+		#html.textField(name="slug",label="Slug (blank to generate it):",maxlength="100",size="30",class="input-block-level",wrapper="div class=controls",labelClass="control-label",groupWrapper="div class=control-group")#
+	</div>
+	<!--- Footer --->
+	<div class="modal-footer">
+		#html.resetButton(name="btnReset",value="Cancel",class="btn", onclick="closeModal( $('##categoryEditorContainer') )")#
+		#html.submitButton(name="btnSave",value="Save",class="btn btn-danger")#
+	</div>
+	#html.endForm()#
+	</div>
+</div>
+</cfif>
 </cfoutput>

--- a/modules/contentbox-admin/views/categories/indexHelper.cfm
+++ b/modules/contentbox-admin/views/categories/indexHelper.cfm
@@ -17,6 +17,7 @@ $(document).ready(function() {
 });
 <cfif prc.oAuthor.checkPermission("CATEGORIES_ADMIN")>
 function edit(categoryID,category,slug){
+    openModal( $("##categoryEditorContainer"), 500, 200 );
 	$categoryEditor.find("##categoryID").val( categoryID );
 	$categoryEditor.find("##category").val( category );
 	$categoryEditor.find("##slug").val( slug );
@@ -26,6 +27,11 @@ function remove(categoryID){
 	$("##delete_"+ categoryID).removeClass( "icon-remove-sign" ).addClass( "icon-spinner icon-spin" );
 	$categoryForm.find("##categoryID").val( categoryID );
 	$categoryForm.submit();
+}
+function createCategory(){
+    // open modal
+	openModal( $("##categoryEditorContainer"), 500, 200 );
+	return false;
 }
 </cfif>
 </script>

--- a/modules/contentbox-admin/views/permissions/indexHelper.cfm
+++ b/modules/contentbox-admin/views/permissions/indexHelper.cfm
@@ -32,6 +32,7 @@ function remove(permissionID){
 	$permissionForm.submit();
 }
 function createPermission(){
+    // open modal
 	openModal( $("##permissionEditorContainer"), 500, 200 );
 	return false;
 }

--- a/modules/contentbox-admin/views/roles/indexHelper.cfm
+++ b/modules/contentbox-admin/views/roles/indexHelper.cfm
@@ -31,6 +31,7 @@ function remove(roleID){
 	$roleForm.submit();
 }
 function createRole(){
+    // open modal
 	openModal( $("##roleEditorContainer"), 500, 200 );
 	return false;
 }


### PR DESCRIPTION
Updated category management page to use modal for add/edit, to emulate
new approach for roles/permissions.

Also added some logic into the general modal management to clear form
fields when a modal is cleared. This resolves some errors I noticed
with the new role/permissions management where if you edit, and then
create, the new item is actually an update of the previously-edited
item. Clearing the form fields prevents this from happening.
