### PR TITLE
CONTENTBOX-158: Fix CKEditor Width/Alignment

### DIFF
--- a/modules/contentbox-admin/views/entries/editor.cfm
+++ b/modules/contentbox-admin/views/entries/editor.cfm
@@ -54,7 +54,7 @@
 					#html.select(name="contentEditorChanger", 
 								 options=prc.editors,
 								 column="name",
-								 class="span2",
+								 class="textfield",
 								 nameColumn="displayName",
 								 selectedValue=prc.defaultEditor,
 								 onchange="switchEditor(this.value)")#
@@ -62,7 +62,7 @@
 					<!--- markup --->
 					<label for="markup" class="inline">Markup: </label>
 					#html.select(name="markup", 
-								 class="span2",
+								 class="textfield",
 								 options=prc.markups,
 								 selectedValue=( prc.entry.isLoaded() ? prc.entry.getMarkup() : prc.defaultMarkup ))#
 					

--- a/modules/contentbox-admin/views/pages/editor.cfm
+++ b/modules/contentbox-admin/views/pages/editor.cfm
@@ -53,7 +53,7 @@
 				#html.select(name="contentEditorChanger", 
 							 options=prc.editors,
 							 column="name",
-							 class="span2",
+							 class="textfield",
 							 nameColumn="displayName",
 							 selectedValue=prc.defaultEditor,
 							 onchange="switchEditor(this.value)")#
@@ -61,7 +61,7 @@
 				<!--- markup --->
 				<label for="markup" class="inline">Markup: </label>
 				#html.select(name="markup", 
-							 class="span2",
+							 class="textfield",
 							 options=prc.markups,
 							 selectedValue=( prc.page.isLoaded() ? prc.page.getMarkup() : prc.defaultMarkup ))#
 				


### PR DESCRIPTION
It seems the "span2" class on the markup and editor drop-downs above
CKeditor are causing the issue. Changing the class to "textfield" seems
to resolve the issue, and also fixes another weird issue with the label
alignment on those fields.
