### PR TITLE
CONTENTBOX-200 Remove extra URLDecode

### DIFF
--- a/modules/contentbox-ui/handlers/page.cfc
+++ b/modules/contentbox-ui/handlers/page.cfc
@@ -186,9 +186,6 @@ component extends="content" singleton{
 		event.paramValue("page",1);
 		event.paramValue("q","");
 
-		// Decode search term
-		rc.q = URLDecode( rc.q );
-
 		// prepare paging plugin
 		prc.pagingPlugin 		= getMyPlugin(plugin="Paging", module="contentbox");
 		prc.pagingBoundaries	= prc.pagingPlugin.getBoundaries(pagingMaxRows=prc.cbSettings.cb_search_maxResults);


### PR DESCRIPTION
contentbox-ui/handlers/page.cfc has an unnecessary call to URLDecode in the search action:
// Decode search term
rc.q = URLDecode( rc.q );
ColdFusion already decodes form and URL variables so there is no need to manually decode them. Furthermore, this actually breaks the search functionality if a user is trying to search for a string that happens to contain a URL encoded entity. For example, if a page contains the text "%26" and you try to search your site for the string "%26", you can't because the search handler will incorrectly turn the "%26" into "&" and search for an ampersand instead.
The two lines of code above need to simply be removed from the search action. If there was some related functionality that was dependent on the decoding, it is probably incorrect.

https://ortussolutions.atlassian.net/browse/CONTENTBOX-200
