### PR TITLE
CONTENTBOX-202 fixed DBSearch display issues.

### DIFF
--- a/modules/contentbox/model/search/DBSearch.cfc
+++ b/modules/contentbox/model/search/DBSearch.cfc
@@ -101,12 +101,20 @@ component accessors="true" implements="contentbox.model.search.ISearchAdapter" s
 				writeOutput('
 				<li>
 					<a href="#cb.linkContent(item)#">#item.getTitle()#</a><br/>
-					#stripHTML( highlightSearchTerm( searchTerm, item.renderContent() ) )#
+					#highlightSearchTerm( searchTerm, stripHTML( item.renderContent() ))#					 
 				</li>
-				<cite>#item.getContentType()# -> #cb.linkContent(item)#</cite><br/>
-				<cite>Categories: #item.getCategoriesList()#</cite>
-				<br /><br />
+				<cite>#item.getContentType()# -> <a href="#cb.linkContent(item)#">#cb.linkContent(item)#</a></cite><br/>
 				');
+				
+				
+				if(item.hasCategories()) {
+					writeOutput('
+					<cite>Categories: #item.getCategoriesList()#</cite><br />
+					');	
+				}
+				
+				writeOutput('<br />');
+								
 			};
 
 			writeOutput("</ul></div>");
@@ -119,7 +127,7 @@ component accessors="true" implements="contentbox.model.search.ISearchAdapter" s
 	* utility to strip HTML
 	*/
 	private function stripHTML(stringTarget){
-		return HTMLEditFormat( REReplaceNoCase(arguments.stringTarget,"<[^>]*>","","ALL") );
+		return REReplaceNoCase(arguments.stringTarget,"<[^>]*>","","ALL");		 											 
 	}
 
 	/**


### PR DESCRIPTION
DBSearch is stripping HTML after highlighting the search which is counter-productive since it stripping the highlight back out.
The highlight also truncates the text such that the StripHTML function leaves parts of tags at the beginning or end of the string.
I also don't think the HTMLEditFormat is necessary. If the content has escaped HTML entities such as   is messes those up so the HTML shows up on the search results screen.
Also, to help clean up redundant and unhelpful data, modify the categories to only display if there are actually categories assigned to that piece of content.
Additionally, to make the search page more user-friendly, make the full URL at the bottom of the excerpt an actual link so the user can click on it as well.

https://ortussolutions.atlassian.net/browse/CONTENTBOX-202
