### PR TITLE
CONTENTBOX-204 Consider context path for assets

### DIFF
--- a/modules/contentbox-installer/handlers/Home.cfc
+++ b/modules/contentbox-installer/handlers/Home.cfc
@@ -11,7 +11,7 @@ component{
 		var prc = event.getCollection(private=true);
 		// setup asset root from administrator as that is the holder of 
 		// all things assets :)
-		prc.assetRoot = getModuleSettings("contentbox-admin").mapping;
+		prc.assetRoot = GetContextRoot() & getModuleSettings("contentbox-admin").mapping;
 	}
 
 	function index(event,rc,prc){


### PR DESCRIPTION
Using the WAR installation, if ContentBox is deployed to a context root path other than "/", all assets are broken as the asset path assumes the web root is immediately after the domain.
