### PR TITLE
Fixed bug with latestSnapshot() private request collection

### DIFF
--- a/modules/contentbox-admin/handlers/dashboard.cfc
+++ b/modules/contentbox-admin/handlers/dashboard.cfc
@@ -43,7 +43,7 @@ component extends="baseHandler"{
 	}
 	
 	// latest snapshot
-	function latestSnapshot(event,rc,rpc){
+	function latestSnapshot(event,rc,prc){
 		// Few counts
 		prc.entriesCount			= entryService.count();
 		prc.pagesCount 				= pageService.count();


### PR DESCRIPTION
latestSnapshot() was accepting rpc instead of prc for the third argument
