### PR TITLE
Fixed latestSnapshot() private request collection argument

### DIFF
--- a/modules/contentbox-admin/handlers/dashboard.cfc
+++ b/modules/contentbox-admin/handlers/dashboard.cfc
@@ -43,7 +43,7 @@ component extends="baseHandler"{
 	}
 	
 	// latest snapshot
-	function latestSnapshot(event,rc,rpc){
+	function latestSnapshot(event,rc,prc){
 		// Few counts
 		prc.entriesCount			= entryService.count();
 		prc.pagesCount 				= pageService.count();


### PR DESCRIPTION
latestSnapshot() was receiving event,rc,rpc when it should have been receiving event,rc,prc

This was breaking the dashboard.
