### PR TITLE
Updated Content.cfc to Fix validateCommentPost message for blank comment

### DIFF
--- a/modules/contentbox-ui/handlers/content.cfc
+++ b/modules/contentbox-ui/handlers/content.cfc
@@ -179,7 +179,7 @@ component{
 		if( !len(rc.author) ){ arrayAppend(commentErrors,"Your name is missing!"); }
 		if( !len(rc.authorEmail) OR NOT validator.checkEmail(rc.authorEmail)){ arrayAppend(commentErrors,"Your email is missing or is invalid!"); }
 		if( len(rc.authorURL) AND NOT validator.checkURL(rc.authorURL) ){ arrayAppend(commentErrors,"Your website URL is invalid!"); }
-		if( !len(rc.content) ){ arrayAppend(commentErrors,"Your URL is invalid!"); }
+		if( !len(rc.content) ){ arrayAppend(commentErrors,"Please provide a comment!"); }
 
 		// Captcha Validation
 		if( prc.cbSettings.cb_comments_captcha AND NOT getMyPlugin(plugin="Captcha",module="contentbox").validate( rc.captchacode ) ){


### PR DESCRIPTION
I was having issues when troubleshooting a commenting issue on my blog, and noticed I was getting 'Invalid Url', instead of 'Comment cannot be empty' style response... so updated it to something more meaningful and accurate.
