### PR TITLE
Fire page not found interceptor prior to new HTTP status

### DIFF
--- a/modules/contentbox-ui/handlers/page.cfc
+++ b/modules/contentbox-ui/handlers/page.cfc
@@ -130,16 +130,16 @@ component extends="content" singleton{
 			// missing page
 			prc.missingPage 	 = incomingURL;
 			prc.missingRoutedURL = event.getCurrentRoutedURL();
+			
+			// announce event
+			announceInterception("cbui_onPageNotFound",{page=prc.page,missingPage=prc.missingPage,routedURL=prc.missingRoutedURL});
 
 			// set 404 headers
 			event.setHTTPHeader("404","Page not found");
 
 			// set skin not found
 			event.setLayout(name="#prc.cbLayout#/layouts/pages", module="contentbox")
-				.setView(view="#prc.cbLayout#/views/notfound", module="contentbox");
-				
-			// announce event
-			announceInterception("cbui_onPageNotFound",{page=prc.page,missingPage=prc.missingPage,routedURL=prc.missingRoutedURL});
+				.setView(view="#prc.cbLayout#/views/notfound", module="contentbox");				
 
 		}
 	}


### PR DESCRIPTION
If the interceptor tries to salvage the page by loading something else
(like in the case of the BlogCFC compat SES URL module) it has to
manually set the status code BACK to 200.  Waiting to change the status
code to 404 until after the interceptor has had a whack at it removes
that burden from the interceptor.
