### PR TITLE
Uppercase error on ubuntu

### DIFF
--- a/modules/contentbox/models/ui/ThemeService.cfc
+++ b/modules/contentbox/models/ui/ThemeService.cfc
@@ -344,7 +344,7 @@ component accessors="true" threadSafe singleton{
 				continue;
 
 			// Check for theme descriptor by 'theme.cfc' or '#themeName#.cfc'
-			var descriptorPath 		= variables.themesPath & "/#themeName#/theme.cfc";
+			var descriptorPath 		= variables.themesPath & "/#themeName#/Theme.cfc";
 			var descriptorInstance 	= variables.themesInvocationPath & ".#themeName#.Theme";
 			if( !fileExists( descriptorPath ) ){
 				// try by theme name instead


### PR DESCRIPTION
The default theme has a Theme.cfc descripor path, on a shared hosting it cannot be found and throws error.