### PR TITLE
564 - Store Sidebar State

### DIFF
--- a/modules/contentbox-admin/includes/spacelab/js/application.js
+++ b/modules/contentbox-admin/includes/spacelab/js/application.js
@@ -24,11 +24,21 @@ var app = function() {
     };
 
     var toggleMenuLeft = function() {
-        $('#toggle-left').bind('click', function(e) {
-           $('body').removeClass('off-canvas-open')    
-            var bodyEl = $('#container');
-            ($(window).width() > 768) ? $(bodyEl).toggleClass('sidebar-mini'): $(bodyEl).toggleClass('sidebar-opened');
-        });
+        var $bodyEl = $('#container');
+        $('body').removeClass('off-canvas-open')    
+
+        function toggleAction(){
+            if($(window).width() > 768){
+                $bodyEl.toggleClass('sidebar-mini');
+                state = $bodyEl.hasClass("sidebar-mini");
+            } else {
+                $bodyEl.toggleClass('sidebar-opened');                
+                state = $bodyEl.hasClass("sidebar-opened");
+            }
+            $.cookie('sidemenu-collapsed',state);
+        }
+        
+        $('#toggle-left').bind('click',toggleAction);
     };
 
     var toggleMenuRight = function() {

--- a/modules/contentbox-admin/layouts/admin.cfm
+++ b/modules/contentbox-admin/layouts/admin.cfm
@@ -171,7 +171,12 @@
     <body class="off-canvas">
         <!--- cbadmin Event --->
         #announceInterception( "cbadmin_afterBodyStart" )#
-        <section id="container">
+        <cfset sidemenuClass = "">
+        <cfif structKeyExists(cookie,'sidemenu-collapsed') && cookie['sidemenu-collapsed'] is "true">
+            <cfset sidemenuClass = "sidebar-mini">
+        </cfif>
+
+        <section id="container" class="#sidemenuClass#">
             <header id="header">
 
                 <!--Branding-->


### PR DESCRIPTION
Store Sidebar State in cookie to keep menu state on reload. Had to check cookie in CF on load due to css classes causing menu toggle to lag on page load.