### PR TITLE
rc.parentContent can be empty string

### DIFF
--- a/modules/contentbox-admin/handlers/contentStore.cfc
+++ b/modules/contentbox-admin/handlers/contentStore.cfc
@@ -300,7 +300,7 @@ component extends="baseContentHandler"{
 		content.addNewContentVersion(content=rc.content, changelog=rc.changelog, author=prc.oAuthor);
 
 		// attach a parent page if it exists and not the same
-		if( rc.parentContent NEQ "null" AND content.getContentID() NEQ rc.parentContent ){
+		if( isNumeric(rc.parentContent) AND content.getContentID() NEQ rc.parentContent ){
 			content.setParent( contentStoreService.get( rc.parentContent ) );
 			// update slug
 			content.setSlug( content.getParent().getSlug() & "/" & content.getSlug() );


### PR DESCRIPTION
fixes a bug at least for MSSQL 2008