### PR TITLE
set JRE_HOME only if it exists

### DIFF
--- a/workbench/resources/express/bin/setclasspath.bat
+++ b/workbench/resources/express/bin/setclasspath.bat
@@ -21,7 +21,7 @@ rem endorsed directory.
 rem ---------------------------------------------------------------------------
 
 rem Embedded JRE
-set "JRE_HOME=../jre"
+if exist "../jre/bin/java.exe" set "JRE_HOME=../jre"
 
 rem Make sure prerequisite environment variables are set
 


### PR DESCRIPTION
currently the JRE_HOME is set regardless of whether it exists (Express with JRE) or not (Express without JRE), making the no-JRE version unusable as it overwrites the JRE_HOME variable if set properly in the Environment.  I suspect that the *nix version .sh suffers from the same issue, but have not checked that as of yet.