### PR TITLE
URL decode the file path to prevent issues with spaces, etc.

### DIFF
--- a/modules/contentbox-ui/handlers/media.cfc
+++ b/modules/contentbox-ui/handlers/media.cfc
@@ -22,7 +22,7 @@ component singleton{
 		
 		// Get the requested media path
 		var replacePath = ( len( prc.cbEntryPoint ) ? "#prc.cbEntryPoint#/" : "" ) & event.getCurrentRoute();
-		prc.mediaPath = trim( replacenocase( event.getCurrentRoutedURL(), replacePath, "" ) );
+		prc.mediaPath = trim( replacenocase( URLDecode( event.getCurrentRoutedURL() ), replacePath, "" ) );
 		prc.mediaPath = reReplace( prc.mediaPath, "\/$", "" );
 		
 		// Determine if ColdBox is doing a format extension detection?


### PR DESCRIPTION
I had an issue with images paths containing spaces. When logging, I found the app was looking for a file-system path containing `%20` in it, causing it to fail.

This change url decodes the path before doing all the other transformations.