### PR TITLE
Fix for CONTENTBOX-774: Slug generate a loop of parent slug in ContentStore

### DIFF
--- a/modules/contentbox-admin/handlers/contentStore.cfc
+++ b/modules/contentbox-admin/handlers/contentStore.cfc
@@ -263,8 +263,7 @@ component extends="baseContentHandler"{
 		}
 
 		// slugify the incoming title or slug
-		if( NOT len(rc.slug) ){ rc.slug = rc.title; }
-		rc.slug = variables.HTMLHelper.slugify( rc.slug );
+		rc.slug = ( NOT len( rc.slug ) ? rc.title : variables.HTMLHelper.slugify( ListLast(rc.slug,"/") ) );
 
 		// Verify permission for publishing, else save as draft
 		if( !prc.oAuthor.checkPermission( "CONTENTSTORE_ADMIN" ) ){


### PR DESCRIPTION
I took the slug logic from the pages.cfc handler and applied it here.  This now seems to update the ContentStore slug value properly.