### PR TITLE
Allow `cbCKfileBrowserDefaultEvent` to be overridden

### DIFF
--- a/modules/contentbox-admin/handlers/ckfilebrowser.cfc
+++ b/modules/contentbox-admin/handlers/ckfilebrowser.cfc
@@ -10,7 +10,7 @@ component extends="baseHandler"{
 	// pre handler
 	function preHandler( event, rc, prc, action, eventArguments ){
 		// event to run
-		prc.cbCKfileBrowserDefaultEvent = "contentbox-filebrowser:home.index";
+		prc.cbCKfileBrowserDefaultEvent = event.getPrivateValue( "cbCKfileBrowserDefaultEvent", "contentbox-filebrowser:home.index" );
 		// CKEditor callback, use if incoming, else default it
 		if( !structKeyExists( rc, "callback" ) ){
 			rc.callback = "fbCKSelect";


### PR DESCRIPTION
Using the `event.getPrivateValue( "cbCKfileBrowserDefaultEvent", "contentbox-filebrowser:home.index" )`  allows this setting to be overridden upstream by an interceptor.  

This is necessary if you simply want to intercept and replace the data used by the filebrowser rather than rewrite (and maintain) an entire filebrowser modue.