### PR TITLE
cb_media_directoryRoot needs a default

### DIFF
--- a/modules/contentbox/models/media/MediaService.cfc
+++ b/modules/contentbox/models/media/MediaService.cfc
@@ -106,7 +106,7 @@ component accessors="true" singleton{
 	* @absolute Return the absolute path or relative, if absolute then it expands the path.
 	*/
 	function getCoreMediaRoot( required boolean absolute=false ){
-		var mRoot = settingService.getSetting( "cb_media_directoryRoot" );
+		var mRoot = settingService.getSetting( "cb_media_directoryRoot", "/contentbox/content" );
 		return ( arguments.absolute ? expandPath( mRoot ) : mRoot );
 	}
 	


### PR DESCRIPTION
When the Installer loads, the cb_media_directoryRoot setting does not exist.
This means the media service will error on module load of the filebrowser.
We need to default this, just in case it has not been created yet.
https://ortussolutions.atlassian.net/browse/CONTENTBOX-864