### PR TITLE
Fixes missing variable exception

### DIFF
--- a/modules/contentbox/ModuleConfig.cfc
+++ b/modules/contentbox/ModuleConfig.cfc
@@ -176,6 +176,7 @@ component {
 	 * Example: contentbox.default.cb_media_directoryRoot
 	 */
 	private function loadEnvironmentOverrides(){
+		var settingService      	= wirebox.getInstance( "SettingService@cb" );
 		var oSystem 			= createObject( "java", "java.lang.System" );
 		var environmentSettings = oSystem.getEnv();
 		var overrides 			= {};


### PR DESCRIPTION
The `settingService` variable was not available in this method, which was causing the use of environment overrides to throw the error:

```
Message	variable [SETTINGSERVICE] doesn't exist
Stacktrace	The Error Occurred in
/app/modules/contentbox/ModuleConfig.cfc: line 194 
192: 
193: // Append and override
194: var allSettings = settingService.getAllSettings( asStruct = true );
```