### PR TITLE
Added ContentsCss interceptor to CKEditor.cfc

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/ModuleConfig.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/ModuleConfig.cfc
@@ -34,7 +34,8 @@ component {
 			customInterceptionPoints = [ 
 				"cbadmin_ckeditorToolbar",
 				"cbadmin_ckeditorExtraPlugins",
-				"cbadmin_ckeditorExtraConfig" 
+				"cbadmin_ckeditorExtraConfig",
+				"cbadmin_ckeditorContentsCss"
 			]
 		};
 		

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/models/CKEditor.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/models/CKEditor.cfc
@@ -72,19 +72,19 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 			excerptToolbar 	= deserializeJSON( settingService.getSetting( "cb_editors_ckeditor_excerpt_toolbar" ) )
 		};
 		// Announce the editor toolbar is about to be processed
-		interceptorService.processState( "cbadmin_ckeditorToolbar", iData);
+		interceptorService.processState( "cbadmin_ckeditorToolbar", iData );
 		// Load extra plugins according to our version
 		var iData2 = { extraPlugins = listToArray( settingService.getSetting( "cb_editors_ckeditor_extraplugins" ) ) };
 		// Announce extra plugins to see if user implements more.
-		interceptorService.processState( "cbadmin_ckeditorExtraPlugins", iData2);
+		interceptorService.processState( "cbadmin_ckeditorExtraPlugins", iData2 );
 		// Load extra configuration
 		var iData3 = { extraConfig = "" };
 		// Announce extra configuration
-		interceptorService.processState( "cbadmin_ckeditorExtraConfig", iData3);
+		interceptorService.processState( "cbadmin_ckeditorExtraConfig", iData3 );
 		// Load contentsCss configuration
 		var iData4 = { contentsCss = [] };
 		// Announce extra configuration
-		interceptorService.processState( "cbadmin_ckeditorContentsCss", iData4);
+		interceptorService.processState( "cbadmin_ckeditorContentsCss", iData4 );
 		// Now prepare our JavaScript and load it. No need to send assets to the head as CKEditor comes pre-bundled
 		return compileJS( iData, iData2, iData3, iData4 );
 	}
@@ -181,21 +181,21 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 			$content.ckeditor( function(){}, {
 					#extraPlugins#
 					#extraConfig#
-					contentsCss: ['#arrayToList(arguments.iData4.contentsCss, "','")#'],
+					contentsCss: [ '#arrayToList( arguments.iData4.contentsCss, "', '" )#' ],
 					toolbar: ckToolbar,
 					toolbarCanCollapse: true,
-					height:400,
-					filebrowserBrowseUrl : '#event.buildLink( xehCKFileBrowserURL )#',
-					filebrowserImageBrowseUrl : '#event.buildLink( xehCKFileBrowserURLIMage )#',
-					filebrowserFlashBrowseUrl : '#event.buildLink( xehCKFileBrowserURLFlash )#',
-					baseHref : '#HTML_BASE_URL#/'
+					height: 400,
+					filebrowserBrowseUrl: '#event.buildLink( xehCKFileBrowserURL )#',
+					filebrowserImageBrowseUrl: '#event.buildLink( xehCKFileBrowserURLIMage )#',
+					filebrowserFlashBrowseUrl: '#event.buildLink( xehCKFileBrowserURLFlash )#',
+					baseHref: '#HTML_BASE_URL#/'
 				} );
 				
 			// Active Excerpts
 			if( $withExcerpt ){
-				$excerpt.ckeditor(function(){}, {
+				$excerpt.ckeditor( function(){}, {
 					#extraConfig#
-					contentsCss: ['#arrayToList(arguments.iData4.contentsCss, "','")#'],
+					contentsCss: [ '#arrayToList( arguments.iData4.contentsCss, "', '" )#' ],
 					toolbar: ckExcerptToolbar,
 					toolbarCanCollapse: true,
 					height: 200,

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/models/CKEditor.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-ckeditor/models/CKEditor.cfc
@@ -81,8 +81,12 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 		var iData3 = { extraConfig = "" };
 		// Announce extra configuration
 		interceptorService.processState( "cbadmin_ckeditorExtraConfig", iData3);
+		// Load contentsCss configuration
+		var iData4 = { contentsCss = [] };
+		// Announce extra configuration
+		interceptorService.processState( "cbadmin_ckeditorContentsCss", iData4);
 		// Now prepare our JavaScript and load it. No need to send assets to the head as CKEditor comes pre-bundled
-		return compileJS( iData, iData2, iData3 );
+		return compileJS( iData, iData2, iData3, iData4 );
 	}
 	
 	/**
@@ -139,7 +143,7 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 	/**
 	* Compile the needed JS to display into the screen
 	*/
-	private function compileJS( required iData, required iData2, required iData3 ){
+	private function compileJS( required iData, required iData2, required iData3, required iData4 ){
 		var js 					= "";
 		var event 				= requestService.getContext();
 		var cbAdminEntryPoint 	= event.getValue( name="cbAdminEntryPoint", private=true );
@@ -154,7 +158,7 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 		if( arrayLen( arguments.iData2.extraPlugins ) ){
 			extraPlugins = "extraPlugins : '#arrayToList( arguments.iData2.extraPlugins )#',";
 		}
-		// Determin Extra Configuration
+		// Determine Extra Configuration
 		var extraConfig = "";
 		if( len( arguments.iData3.extraConfig ) ){
 			extraConfig = "#arguments.iData3.extraConfig#,";
@@ -177,6 +181,7 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 			$content.ckeditor( function(){}, {
 					#extraPlugins#
 					#extraConfig#
+					contentsCss: ['#arrayToList(arguments.iData4.contentsCss, "','")#'],
 					toolbar: ckToolbar,
 					toolbarCanCollapse: true,
 					height:400,
@@ -190,6 +195,7 @@ component implements="contentbox.models.ui.editors.IEditor" accessors="true" sin
 			if( $withExcerpt ){
 				$excerpt.ckeditor(function(){}, {
 					#extraConfig#
+					contentsCss: ['#arrayToList(arguments.iData4.contentsCss, "','")#'],
 					toolbar: ckExcerptToolbar,
 					toolbarCanCollapse: true,
 					height: 200,


### PR DESCRIPTION
This allows easier inclusion of multiple css files for CKEditor ContentsCss.  Especially helps when multiple modules need to add css to CKEditor ContentsCss.