### PR TITLE
The operator == does not work in CF

### DIFF
--- a/modules/contentbox/modules/contentbox-ui/views/adminbar/index.cfm
+++ b/modules/contentbox/modules/contentbox-ui/views/adminbar/index.cfm
@@ -5,7 +5,7 @@
 		
 		<cfif !isNull( args.oContent )>
 			
-			<cfif args.oContent.getContentType() == "Page">
+			<cfif args.oContent.getContentType() eq "Page">
 			<span class="admin-bar-label">
 				Layout: #args.oContent.getLayout()#
 			</span>


### PR DESCRIPTION
I installed and ran contentbox with commandbox, and at some point when trying to see a preview I got an error 

> Type: Template
Messages: Invalid CFML construct found on line 8 at column 62. ColdFusion was looking at the following text:
=
Then I changed the operator "==" for "eq" I think that operator only works on Lucee 