### PR TITLE
Added pagination to ForgeBox installer

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/handlers/forgebox.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/forgebox.cfc
@@ -14,15 +14,17 @@ component extends="baseHandler"{
 	function index( event, rc, prc ){
 		// order by
 		event.paramValue( "orderBy", "POPULAR" );
+		event.paramValue( "startrow", "0" );
 
 		// exit Handlers
 		prc.xeh 				= "#prc.cbAdminEntryPoint#.layouts.remove";
 		prc.xehForgeBoxInstall  = "#prc.cbAdminEntryPoint#.forgebox.install";
+		prc.xehForgeBox			= "#prc.cbAdminEntryPoint#.forgebox.index";
 		prc.markdown 			= variables.markdown;
 
 		// get entries
 		try{
-			prc.entries = forgebox.getEntries( orderBy=forgebox.ORDER[ rc.orderBy ], typeSlug=rc.typeslug );
+			prc.entries = forgebox.getEntries( orderBy=forgebox.ORDER[ rc.orderBy ], typeSlug=rc.typeslug, startrow=rc.startrow );
 			prc.errors = false;
 		} catch( Any e ) {
 			prc.errors = true;

--- a/modules/contentbox/modules/contentbox-admin/views/forgebox/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/forgebox/index.cfm
@@ -191,6 +191,31 @@
 			</p>
 		</div>
 		</cfloop>
+
+		<cfif prc.entries.totalRecords gt 25>
+			<ul class="pagination pull-right">
+				<cfset count = 0>
+				<cfparam name="rc.page" default="1">
+
+				<cfif rc.page neq 1>
+					<li aria-controls="pages">
+						<a class="forge-box-page-btn" data-page="#rc.page - 1#">Previous</a>
+					</li>
+				</cfif>
+
+				<cfloop from="1" to="#prc.entries.totalRecords#" index="i" step="25">
+					<li<cfif rc.page eq ++count> class="active"</cfif> aria-controls="pages">
+						<a class="forge-box-page-btn"<cfif rc.page neq count> data-page="#count#"</cfif>>#count#</a>
+					</li>
+				</cfloop>
+
+				<cfif rc.page lt count>
+					<li aria-controls="pages">
+						<a class="forge-box-page-btn" data-page="#rc.page + 1#">Next</a>
+					</li>
+				</cfif>
+			</ul>
+		</cfif>
 	</cfif>
 #html.endForm()#
 </cfoutput>

--- a/modules/contentbox/modules/contentbox-admin/views/forgebox/indexHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/forgebox/indexHelper.cfm
@@ -13,6 +13,9 @@ $(document).ready(function() {
             300
         )
 	)
+	$( ".forge-box-page-btn" ).on( "click", function() {
+		loadForgeBox( $(this).data( "page" ) );
+	} );
 	// tool tips
 	activateTooltips();
 } );
@@ -21,6 +24,17 @@ function installEntry( id, downloadURL ){
 	$downloadURL.val( downloadURL );
 	$forgeBoxInstall.submit();
 	return true;
+}
+function loadForgeBox( page ){
+	var params = { typeslug: '#rc.typeslug#', installDir: '#rc.installDir#', returnURL: '#rc.returnURL#', orderBY: "#rc.orderBY#"};
+
+	if ( !isNaN( page ) ) {
+		params.startrow = ( page - 1 ) * 25;
+		params.page = page;
+	}
+
+	$forgebox.html( '<div class="text-center"><i class="fa fa-spinner fa-spin fa-lg icon-4x"></i><br/>Please wait, connecting to ForgeBox...</div>' );
+	$forgebox.load( '#event.buildLink( prc.xehForgeBox )#', params );
 }
 </script>
 </cfoutput>

--- a/workbench/devincludes/scss/theme/_pagination.scss
+++ b/workbench/devincludes/scss/theme/_pagination.scss
@@ -1,6 +1,7 @@
  .pagination>.active>a, .pagination>.active>span, .pagination>.active>a:hover, .pagination>.active>span:hover, .pagination>.active>a:focus, .pagination>.active>span:focus {
     background-color: $primaryColor;
     border-color: $primaryColor;
+    cursor: pointer;
 }
 .pagination>li>a, .pagination>li>span {
     color: $primaryColor;


### PR DESCRIPTION
Currently there is no way to view more than the first 25 ContentBox modules causing some modules to be hidden from users.  This PR goes along with the PR I made for the ForgeBox SDK.