### PR TITLE
Use encodeURIComponent function instead of escape function

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/indexHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/indexHelper.cfm
@@ -197,7 +197,7 @@ function fbQuickView(){
 	// only images
 	if( target.attr( "data-quickview" ) == "false" ){ alert( '#$r( "jsmessages.quickview_only_images@fb" )#' ); return; }
 	// show it
-	var imgURL = "#event.buildLink( prc.xehFBDownload )#?path="+ escape( target.attr( "data-fullURL" ) );
+	var imgURL = "#event.buildLink( prc.xehFBDownload )#?path="+ encodeURIComponent( target.attr( "data-fullURL" ) );
 	$('.imagepreview').attr('src', imgURL);
 	openModal( $( "##modalPreview" ), 500 );
 }
@@ -337,7 +337,7 @@ function fbDownload(){
 		alert( '#$r( "jsmessages.downloadFolder@fb" )#' ); return;
 	}	
 	// Trigger the download
-	$( "##downloadIFrame" ).attr( "src","#event.buildLink( prc.xehFBDownload )#?path="+ escape(sPath) );
+	$( "##downloadIFrame" ).attr( "src","#event.buildLink( prc.xehFBDownload )#?path="+ encodeURIComponent(sPath) );
 }
 </cfif>
 <!--- CallBack --->


### PR DESCRIPTION
This allows for file paths that have two forward slashes to work when using the file browser quick view and download functions.  This fixes an issue when trying to use s3 to store media.