### PR TITLE
Media manager bug fixes

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
@@ -456,7 +456,7 @@ component{
 		}
 		// Manual uploader?
 		if( rc.manual AND !data.errors) {
-			event.renderData( data="<textarea id='data_result'='upload'>#serializeJSON( data )#</textarea>", type="text" );
+			event.renderData( data=serializeJSON( data ), type="text" );
 		} else {
 			// render stuff out
 			event.renderData( data=data, type="json" );

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/index.cfm
@@ -356,7 +356,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 		enctype="multipart/form-data" 
 		method="POST" 
 		target="upload-iframe" 
-		action="#event.buildLink( prc.xehFBUpload )#?#$safe( session.URLToken )#&folder=#prc.fbSafeCurrentRoot#"
+		action="#event.buildLink( prc.xehFBUpload )#"
 >
 	<input type="hidden" name="path" value='#prc.fbSafeCurrentRoot#' />
 	<input type="hidden" name="manual" value="true" />

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/index.cfm
@@ -178,7 +178,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 							<!--- Directory or File --->
 							<cfif prc.fbqListing.type eq "Dir">
 								<!--- Folder --->
-								<div id="#validIDName#"
+								<div id="fb-dir-#validIDName#"
 									 onClick="javascript:return false;"
 									 class="folders"
 									 data-type="dir"
@@ -195,7 +195,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 								</div>
 							<cfelseif prc.fbSettings.showFiles>
 								<!--- Display the DiV --->
-								<div id="#validIDName#"
+								<div id="fb-file-#validIDName#"
 									 class="files"
 									 data-type="file"
 									 data-name="#prc.fbqListing.Name#"
@@ -225,7 +225,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 					<!--- Directory or File --->
 					<cfif prc.fbqListing.type eq "Dir">
 						<!--- Folder --->
-						<div id="#validIDName#"
+						<div id="fb-dir-#validIDName#"
 							 class="folders filterDiv"
 							 data-type="dir"
 							 data-name="#prc.fbqListing.Name#"
@@ -240,7 +240,7 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 						</div>
 					<cfelseif prc.fbSettings.showFiles>
 						<!--- Display the DiV --->
-						<div id="#validIDName#"
+						<div id="fb-file-#validIDName#"
 							 class="files filterDiv"
 							 data-type="file"
 							 data-name="#prc.fbqListing.Name#"

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/indexHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/views/home/indexHelper.cfm
@@ -402,7 +402,7 @@ $( document ).ready( function(){
 		<cfif len( prc.fbSettings.acceptMimeTypes )>
 		allowedfiletypes : "#prc.fbSettings.acceptMimeTypes#".split( "," ),
 		</cfif>
-		url: '#event.buildLink( prc.xehFBUpload )#?#$safe( session.URLToken )#',
+		url: '#event.buildLink( prc.xehFBUpload )#',
 		data: {
 	        path: '#prc.fbSafeCurrentRoot#'
 	    },


### PR DESCRIPTION
Currently, if you have a folder or file named "Events", it will be displayed very tall and with a green background.  This is because the id for the file or folder is "events" which is also an id of a ContentBox admin element and thus the styles from that element are applied unintentionally to the Events folder.  This PR prefixes the file and folder ids with "fb-file-" or "fb-dir-" to prevent this issue.

I have only noticed this with an Events folder but it has the potential to happen to any other folder that has an id which is styled by the ContentBox admin styles.