### PR TITLE
Improved Two-Factor Enrollment Flow

### DIFF
--- a/modules/contentbox/models/security/twofactor/ITwoFactorProvider.cfc
+++ b/modules/contentbox/models/security/twofactor/ITwoFactorProvider.cfc
@@ -11,16 +11,21 @@ interface{
 	* Get the internal name of a provider, used for registration, internal naming and more.
 	*/
 	function getName();
-	
+
 	/**
 	* Get the display name for the provider.  Used in all UI screens
 	*/
-	function getDisplayName();
+    function getDisplayName();
+
+    /**
+     * Returns html to display to the user for required two-factor fields
+     */
+    function getAuthorSetupForm( required author );
 
 	/**
 	* Get the display help for the provider.  Used in the UI setup screens for the author
 	*/
-	function getAuthorSetupHelp();
+    function getAuthorSetupHelp( required author );
 
 	/**
 	* Get the verification help for the provider.  Used in the UI verification screen.
@@ -36,9 +41,9 @@ interface{
 	/**
 	 * Send a challenge via the 2 factor auth implementation.
 	 * The return must be a struct with an error boolean bit and a messages string
-	 * 
+	 *
 	 * @author The author to challenge
-	 * 
+	 *
 	 * @return struct:{ error:boolean, messages=string }
 	 */
 	struct function sendChallenge( required author );
@@ -55,7 +60,7 @@ interface{
 	struct function verifyChallenge( required string code, required author );
 
 	/**
-	 * This method is called once a two factor challenge is accepted and valid. 
+	 * This method is called once a two factor challenge is accepted and valid.
 	 * Meaning the user has completed the validation and will be logged in to ContentBox now.
 	 *
 	 * @code The verification code

--- a/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
+++ b/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
@@ -12,6 +12,7 @@ component accessors="true" threadSafe singleton{
 	property name="securityService" 	inject="securityService@cb";
 	property name="authorService" 		inject="authorService@cb";
 	property name="cookieStorage" 		inject="cookieStorage@cbStorages";
+	property name="log"                 inject="logbox:logger:{this}";
 
 	/**
 	 * Providers registry
@@ -19,9 +20,9 @@ component accessors="true" threadSafe singleton{
 	property name="providers"	type="struct";
 
 	// Static Properties
-	
+
 	variables.TRUSTED_DEVICE_COOKIE = "contentbox_2factor_device";
-	
+
 	/**
 	* Constructor
 	* @wirebox.inject wirebox
@@ -29,13 +30,13 @@ component accessors="true" threadSafe singleton{
 	TwoFactorService function init( required wirebox ){
 		// init providers
 		variables.providers = {};
-		
+
 		// store factory
 		variables.wirebox = arguments.wirebox;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Are we forcing global two factor authentication
 	 */
@@ -64,32 +65,32 @@ component accessors="true" threadSafe singleton{
 	numeric function getTrustedDeviceTimespan(){
 		return settingService.getSetting( "cb_security_2factorAuth_trusted_days" );
 	}
-	
+
 	/**
 	* Register a new two factor authenticator in ContentBox
 	* @provider The provider instance to register
 	*/
 	TwoFactorService function registerProvider( required contentbox.models.security.twofactor.ITwoFactorProvider provider ){
-		variables.providers[ arguments.provider.getName() ] = arguments.provider;	
+		variables.providers[ arguments.provider.getName() ] = arguments.provider;
 		return this;
 	}
-	
+
 	/**
 	* UnRegister a provider in ContentBox
 	* @name The name of the provider to unregister
 	*/
 	TwoFactorService function unRegisterProvider( required name ){
-		structDelete( variables.providers, arguments.name );	
+		structDelete( variables.providers, arguments.name );
 		return this;
 	}
-	
+
 	/**
 	* Get an array of registered provider names in alphabetical order
 	*/
 	array function getRegisteredProviders(){
 		return listToArray( listSort( structKeyList( variables.providers ), "textnocase" ) );
 	}
-	
+
 	/**
 	* Get an array of registered provider names in alphabetical order with their display names
 	*/
@@ -97,14 +98,14 @@ component accessors="true" threadSafe singleton{
 		var aProviders = getRegisteredProviders();
 		var result = [];
 		for( var thisProvider in aProviders ){
-			arrayAppend( result, { 
-				name        = thisProvider, 
-				displayName = variables.providers[ thisProvider ].getDisplayName() 
+			arrayAppend( result, {
+				name        = thisProvider,
+				displayName = variables.providers[ thisProvider ].getDisplayName()
 			} );
 		}
 		return result;
 	}
-	
+
 	/**
 	* Get a registered provider instance
 	* @name The name of the provider
@@ -126,9 +127,9 @@ component accessors="true" threadSafe singleton{
 	 * @trustedID The trusted ID to track in the tracking cookie
 	 */
 	TwoFactorService function setTrustedDevice( required trustedID ){
-		cookieStorage.setVar( 
-			name    = variables.TRUSTED_DEVICE_COOKIE, 
-			value   = securityService.encryptIt( arguments.trustedID ), 
+		cookieStorage.setVar(
+			name    = variables.TRUSTED_DEVICE_COOKIE,
+			value   = securityService.encryptIt( arguments.trustedID ),
 			expires = getTrustedDeviceTimespan()
 		);
 		return this;
@@ -165,7 +166,7 @@ component accessors="true" threadSafe singleton{
 	boolean function canChallenge( required author ){
 		var oProvider 	= getProvider( getDefaultProvider() );
 		var results 	= false;
-		if( 
+		if(
 			// Verify if global force is enabled
 			isForceTwoFactorAuth()
 			OR
@@ -187,7 +188,7 @@ component accessors="true" threadSafe singleton{
 	/**
 	 * Leverage the default provider to send a challenge to the specific user.
 	 * The return is a structure containing an error flag and a messages string.
-	 * 
+	 *
 	 * @author The author to challenge
 	 *
 	 * @return struct:{ error:boolean, messages:string }

--- a/modules/contentbox/modules/contentbox-admin/ModuleConfig.cfc
+++ b/modules/contentbox/modules/contentbox-admin/ModuleConfig.cfc
@@ -136,7 +136,9 @@ component {
 			// Admin Comment Cleanup/Moderation listener
 			{ class="#moduleMapping#.interceptors.CommentCleanup", name="CommentCleanup@cbAdmin" },
 			// Admin MenuBuilder Cleanups
-			{ class="#moduleMapping#.interceptors.MenuCleanup", name="MenuCleanup@cbAdmin" }
+            { class="#moduleMapping#.interceptors.MenuCleanup", name="MenuCleanup@cbAdmin" },
+            // Unenroll Two Factor on Provider Change
+			{ class="#moduleMapping#.interceptors.UnenrollTwoFactorOnProviderChange", name="UnenrollTwoFactorOnProviderChange@cbAdmin" }
 		];
 
 	}

--- a/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
@@ -315,6 +315,26 @@ component extends="baseHandler"{
         flash.put( "authorID", rc.authorID );
         prc.oAuthor = authorService.get( id=rc.authorID );
 
+        // iterate rc keys that start with "preference."
+        var allPreferences 	= {};
+		for( var key in rc ){
+			if( reFindNoCase( "^preference\.", key ) ){
+				allPreferences[ listLast( key, "." ) ] = rc[ key ];
+			}
+		}
+        prc.oAuthor.setPreferences( allPreferences );
+        populateModel( model = prc.oAuthor, exclude = "preference" );
+        var vResults = validateModel( target = prc.oAuthor, excludes = "password" );
+		if ( vResults.hasErrors() ) {
+            cbMessagebox.warn( messageArray=vResults.getAllErrors() );
+            setNextEvent(
+                event		= prc.xehAuthorEditor,
+                queryString	= "authorID=#prc.oAuthor.getAuthorID()###twofactor"
+            );
+        }
+
+        authorService.saveAuthor( prc.oAuthor );
+
         prc.xehValidate = "#prc.cbadminEntryPoint#.authors.doTwoFactorEnrollment";
         prc.xehResend 	= "#prc.cbadminEntryPoint#.authors.enrollTwoFactor";
         prc.provider 	= twoFactorService.getDefaultProviderObject();

--- a/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
@@ -440,6 +440,7 @@ component extends="baseHandler"{
 	* @return html
 	*/
 	function editor( event, rc, prc ){
+        prc.htmlTitle = "Author Editor";
 		// exit handlers
 		prc.xehAuthorsave 			= "#prc.cbAdminEntryPoint#.authors.save";
 		prc.xehAuthorPreferences 	= "#prc.cbAdminEntryPoint#.authors.savePreferences";

--- a/modules/contentbox/modules/contentbox-admin/interceptors/UnenrollTwoFactorOnProviderChange.cfc
+++ b/modules/contentbox/modules/contentbox-admin/interceptors/UnenrollTwoFactorOnProviderChange.cfc
@@ -1,0 +1,25 @@
+/**
+* ContentBox - A Modular Content Platform
+* Copyright since 2012 by Ortus Solutions, Corp
+* www.ortussolutions.com/products/contentbox
+* ---
+* Unenroll users from two-factor authentication on provider change
+*/
+component extends="coldbox.system.Interceptor"{
+
+    /**
+    * Configure
+    */
+    function configure(){}
+
+    /**
+     * Fires after the save of a page
+     * Will cleanup any slug changes for menus
+     */
+    public void function cbadmin_preSettingsSave( required any event, required struct interceptData ) {
+        if ( interceptData.oldSettings.cb_security_2factorAuth_provider != interceptData.newSettings.cb_security_2factorAuth_provider ) {
+            queryExecute( "UPDATE cb_author SET is2FactorAuth = 0" );
+        }
+    }
+
+}

--- a/modules/contentbox/modules/contentbox-admin/interceptors/UnenrollTwoFactorOnProviderChange.cfc
+++ b/modules/contentbox/modules/contentbox-admin/interceptors/UnenrollTwoFactorOnProviderChange.cfc
@@ -13,8 +13,7 @@ component extends="coldbox.system.Interceptor"{
     function configure(){}
 
     /**
-     * Fires after the save of a page
-     * Will cleanup any slug changes for menus
+     * Unenrolls all users from two-factor authentication on two-factor provider change
      */
     public void function cbadmin_preSettingsSave( required any event, required struct interceptData ) {
         if ( interceptData.oldSettings.cb_security_2factorAuth_provider != interceptData.newSettings.cb_security_2factorAuth_provider ) {

--- a/modules/contentbox/modules/contentbox-admin/layouts/inc/HTMLHead.cfm
+++ b/modules/contentbox/modules/contentbox-admin/layouts/inc/HTMLHead.cfm
@@ -9,8 +9,12 @@
     <!--- SES --->
     <base href="#cb.siteBaseURL()#" />
     <!--- Title --->
-    <cfif structKeyExists( prc, 'cb_site_name' )>
-        <title>#prc.cbSettings.cb_site_name# - ContentBox Administrator</title>        
+    <cfif event.privateValueExists( "htmlTitle" )>
+        <title>#prc.htmlTitle# &mdash; ContentBox Administrator</title>
+    <cfelseif structKeyExists( prc, 'cbSettings' )>
+        <title>#prc.cbSettings.cb_site_name# &mdash; ContentBox Administrator</title>
+    <cfelse>
+        <title>ContentBox Administrator</title>
     </cfif>
     <!--- Description --->
     <meta name="description" content="ContentBox Modular CMS - Admin">

--- a/modules/contentbox/modules/contentbox-admin/layouts/simple.cfm
+++ b/modules/contentbox/modules/contentbox-admin/layouts/simple.cfm
@@ -1,0 +1,38 @@
+<cfoutput>
+#html.doctype()#
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+<!--<![endif]-->
+    <cfinclude template="#prc.cbroot#/layouts/inc/HTMLHead.cfm"/>
+	<body class="animated fadeIn">
+		<!--- cbadmin Event --->
+		#announceInterception( "cbadmin_afterLoginBodyStart" )#
+		<section id="container">
+            <header id="header">
+            	<!--logo start-->
+                <div class="brand text-center">
+                    <a class="logo">
+                        <img src="#prc.cbRoot#/includes/images/ContentBox_90.png"/>
+                    </a>
+                </div>
+            </header>
+        </section>
+
+    	<!--- Login Container --->
+		<section id="login-container">
+			<!--- cbadmin event --->
+			#announceInterception( "cbadmin_beforeLoginContent" )#
+			<!--- Main Content --->
+			#renderView()#
+			<!--- cbadmin event --->
+			#announceInterception( "cbadmin_afterLoginContent" )#
+		</section>
+
+
+        <cfinclude template="#prc.cbroot#/layouts/inc/HTMLBodyEnd.cfm"/>
+	</body>
+</html>
+</cfoutput>

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/ModuleConfig.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/ModuleConfig.cfc
@@ -22,7 +22,7 @@ component {
 
 		// Layout Settings
 		layoutSettings = { defaultLayout = "simple.cfm" };
-	
+
 		// i18n
 		i18n = {
 			resourceBundles = {
@@ -38,13 +38,13 @@ component {
 			{ pattern="/:action", handler="security" },
 			{ pattern="/:handler/:action?" }
 		];
-		
+
 		// Custom Declared Points
 		interceptorSettings = {
 			// CB Admin Custom Events
 			customInterceptionPoints = [
 				// Login Layout HTML points
-				"cbadmin_beforeLoginHeadEnd", "cbadmin_afterLoginBodyStart", "cbadmin_beforeLoginBodyEnd", 
+				"cbadmin_beforeLoginHeadEnd", "cbadmin_afterLoginBodyStart", "cbadmin_beforeLoginBodyEnd",
 				"cbadmin_loginFooter", "cbadmin_beforeLoginContent", "cbadmin_afterLoginContent",
 				// Login Form
 				"cbadmin_beforeLoginForm", "cbadmin_afterLoginForm",
@@ -58,20 +58,24 @@ component {
 				"cbadmin_beforeTwoFactorForm","cbadmin_afterTwoFactorForm", "cbadmin_onInvalidTwoFactor", "cbadmin_onValidTwoFactor"
 			]
 		};
-		
+
 		// interceptors
 		interceptors = [
 			// ContentBox security via cbSecurity Module
-			{ 
+			{
 				class 		= "cbsecurity.interceptors.Security",
 			  	name 		= "security@cb",
 			  	properties 	= {
 			 		rulesSource 		= "model",
 			 		rulesModel			= "securityRuleService@cb",
 			 		rulesModelMethod 	= "getSecurityRules",
-			 		validatorModel 		= "securityService@cb" 
+			 		validatorModel 		= "securityService@cb"
 			 	}
-			}
+            },
+            {
+                class = "#moduleMapping#.interceptors.CheckForForceTwoFactorEnrollment",
+                name = "CheckForForceTwoFactorEnrollment@contentbox-security"
+            }
 		];
 
 	}

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/security.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/security.cfc
@@ -78,8 +78,8 @@ component extends="baseHandler"{
 			// Verify if we have to challenge via two factor auth
 			if( twoFactorService.canChallenge( results.author ) ){
 				// Flash data needed for authorizations
-				flash.put( "authorData", { 
-					authorID 	= results.author.getAuthorID(), 
+				flash.put( "authorData", {
+					authorID 	= results.author.getAuthorID(),
 					rememberMe 	= rc.rememberMe,
 					securedURL  = rc._securedURL
 				} );
@@ -87,7 +87,7 @@ component extends="baseHandler"{
 				var twoFactorResults = twoFactorService.sendChallenge( results.author );
 				// Verify error, if so, log it and setup a messagebox
 				if( twoFactorResults.error ){
-					log.error( twoFactorResults.messages ); 
+					log.error( twoFactorResults.messages );
 					messagebox.error( cb.r( "twofactor.error@security" ) );
 				}
 				// Relocate to two factor auth presenter
@@ -101,14 +101,14 @@ component extends="baseHandler"{
 
 			// announce event
 			announceInterception( "cbadmin_onLogin", { author = results.author, securedURL = rc._securedURL } );
-			
+
 			// check if securedURL came in?
 			if( len( rc._securedURL ) ){
 				setNextEvent( uri=rc._securedURL );
 			} else {
 				setNextEvent( "#prc.cbAdminEntryPoint#.dashboard" );
 			}
-		} 
+		}
 		// INVALID LOGINS
 		else {
 			// announce event
@@ -165,7 +165,7 @@ component extends="baseHandler"{
 			arrayAppend( errors, "#cb.r( 'validation.need_email@security' )#<br />" );
 		} else {
 			// Try To get the Author
-			oAuthor = authorService.findWhere( { email = rc.email } );
+			oAuthor = authorService.findWhere( { email = rc.email, isActive = 1 } );
 			if( isNull( oAuthor ) OR NOT oAuthor.isLoaded() ){
 				// Don't give away that the email did not exist.
 				messagebox.info( cb.r( resource='messages.lostpassword_check@security', values="5" ) );
@@ -209,7 +209,7 @@ component extends="baseHandler"{
 			messagebox.error( cb.r( "messages.invalid_token@security" ) );
 			setNextEvent( "#prc.cbAdminEntryPoint#.security.lostPassword" );
 			return;
-		} 
+		}
 
 		// Present rest password page.
 		prc.xehPasswordChange = "#prc.cbAdminEntryPoint#.security.doPasswordChange";
@@ -253,7 +253,7 @@ component extends="baseHandler"{
 			messagebox.error( cb.r( "messages.invalid_token@security" ) );
 			setNextEvent( "#prc.cbAdminEntryPoint#.security.lostPassword" );
 			return;
-		} 
+		}
 
 		// Validate you are not using the same password if persisted already
 		if( authorService.isSameHash( rc.password, results.author.getPassword() ) ){
@@ -275,11 +275,11 @@ component extends="baseHandler"{
 		if( resetResults.error ){
 			// announce event
 			announceInterception( "cbadmin_onInvalidPasswordReset", { token = rc.token } );
-			messagebox.error( resetResults.messages );	
+			messagebox.error( resetResults.messages );
 			setNextEvent( "#prc.cbAdminEntryPoint#.security.lostPassword" );
 			return;
 		}
-		
+
 		// announce event and relcoate to login with new password
 		announceInterception( "cbadmin_onPasswordReset", { author = results.author  } );
 		messagebox.info( cb.r( "messages.password_reset@security" ) );

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/twofactor.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/twofactor.cfc
@@ -61,9 +61,9 @@ component extends="baseHandler"{
 		var authorData = flash.get( "authorData" );
 
 		// Verify the challenge code
-		var results = twoFactorService.verifyChallenge( 
-			code   = rc.twofactorcode, 
-			author = prc.oAuthor 
+		var results = twoFactorService.verifyChallenge(
+			code   = rc.twofactorcode,
+			author = prc.oAuthor
 		);
 
 		// Check for errors
@@ -85,12 +85,12 @@ component extends="baseHandler"{
 			securityService.setRememberMe( prc.oAuthor.getUsername(), val( authorData.rememberMe ) );
 			// Set in session, validations are now complete
 			securityService.setAuthorSession( prc.oAuthor );
-			
+
 			// announce events
 			announceInterception( "cbadmin_onValidTwoFactor", { author = prc.oAuthor } );
 			// announce event
 			announceInterception( "cbadmin_onLogin", { author = prc.oAuthor, securedURL = authorData.securedURL } );
-			
+
 			// check if securedURL came in?
 			if( len( authorData.securedURL ) ){
 				setNextEvent( uri=authorData.securedURL );
@@ -108,7 +108,7 @@ component extends="baseHandler"{
 		var twoFactorResults = twoFactorService.sendChallenge( prc.oAuthor );
 		// Verify error, if so, log it and setup a messagebox
 		if( twoFactorResults.error ){
-			log.error( prc.twoFactorResults.messages );
+			log.error( twoFactorResults.messages );
 			messagebox.error( cb.r( "twofactor.error@security" ) );
 		} else {
 			// message and redirect

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/interceptors/CheckForForceTwoFactorEnrollment.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/interceptors/CheckForForceTwoFactorEnrollment.cfc
@@ -1,0 +1,48 @@
+/**
+* ContentBox - A Modular Content Platform
+* Copyright since 2012 by Ortus Solutions, Corp
+* www.ortussolutions.com/products/contentbox
+* ---
+* Unenroll users from two-factor authentication on provider change
+*/
+component extends="coldbox.system.Interceptor"{
+
+    property name="twoFactorService" inject="id:TwoFactorService@cb";
+
+    variables.allowedEvents = [
+        "contentbox-admin:authors.forceTwoFactorEnrollment",
+        "contentbox-admin:authors.enrollTwofactor",
+        "contentbox-admin:authors.forceTwoFactorEnrollment",
+        "contentbox-admin:authors.doTwoFactorEnrollment"
+    ];
+
+
+    /**
+    * Configure
+    */
+    function configure(){}
+
+    /**
+     *
+     */
+    public void function preProcess( required any event, required struct interceptData, buffer, rc, prc ) {
+        if ( ! prc.oCurrentAuthor.getLoggedIn() ) {
+            return;
+        }
+
+        if ( ! twoFactorService.isForceTwoFactorAuth() ) {
+            return;
+        }
+
+        if ( prc.oCurrentAuthor.getIs2FactorAuth() ) {
+            return;
+        }
+
+        if ( arrayContains( allowedEvents, rc.event ) ) {
+            return;
+        }
+
+        event.overrideEvent( "contentbox-admin:authors.forceTwoFactorEnrollment" );
+    }
+
+}

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/modules/contentbox-email-twofactor/models/EmailTwoFactorProvider.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/modules/contentbox-email-twofactor/models/EmailTwoFactorProvider.cfc
@@ -6,7 +6,7 @@
 * Provides email two factor authentication. This provider leverages the `template` cache
 * to store unique tokens.
 */
-component 
+component
 	extends="contentbox.models.security.twofactor.BaseTwoFactorProvider"
 	implements="contentbox.models.security.twofactor.ITwoFactorProvider"
 	singleton
@@ -33,18 +33,28 @@ component
 	function getName(){
 		return "email";
 	}
-	
+
 	/**
 	* Get the display name of the provider
 	*/
 	function getDisplayName(){
 		return "Email";
-	};
+    };
+
+    /**
+     * Returns html to display to the user for required two-factor fields
+     */
+    function getAuthorSetupForm( required author ) {
+        return '
+            <label class="control-label" for="email">Email: </label>
+            <input class="form-control" disabled type="email" id="email" name="email" value="#author.getEmail()#" />
+        ';
+    }
 
 	/**
 	* Get the display help for the provider.  Used in the UI setup screens for the author
 	*/
-	function getAuthorSetupHelp(){
+	function getAuthorSetupHelp( required author ){
 		return "Make sure you have a valid email address setup in your author details.  We will use this email account
 			to send you verification tokens to increase your account's security.";
 	}
@@ -57,7 +67,7 @@ component
 	}
 
 	/**
-	* Get the author options form. This will be sent for saving. You can listen to save operations by 
+	* Get the author options form. This will be sent for saving. You can listen to save operations by
 	* listening to the event 'cbadmin_onAuthorTwoFactorSaveOptions'
 	*/
 	function getAuthorOptions(){
@@ -79,7 +89,7 @@ component
 	 */
 	string function generateValidationToken( required author ){
 		// Store Security Token For X minutes
-		var token = left( 
+		var token = left(
 			hash( arguments.author.getEmail() & arguments.author.getAuthorID() & now() ),
 			6
 		);
@@ -96,9 +106,9 @@ component
 	/**
 	 * Send a challenge via the 2 factor auth implementation.
 	 * The return must be a struct with an error boolean bit and a messages string
-	 * 
+	 *
 	 * @author The author to challenge
-	 * 
+	 *
 	 * @return struct:{ error:boolean, messages=string }
 	 */
 	struct function sendChallenge( required author ){
@@ -153,21 +163,21 @@ component
 			} else {
 				results.messages = "Validation code sent!";
 			}
-			
+
 			// Send it to the user
 		} catch( Any e ){
 			results.error 		= true;
-			results.messages 	= "Error Sending Email Challenge: #e.message# #e.detail#"; 
+			results.messages 	= "Error Sending Email Challenge: #e.message# #e.detail#";
 			// Log this.
 			log.error( "Error Sending Email Challenge: #e.message# #e.detail#", e );
 		}
-		
+
 		return results;
 	}
 
 	/**
-	 * Verify the challenge 
-	 * 
+	 * Verify the challenge
+	 *
 	 * @code The verification code
 	 * @author The author to verify challenge
 	 *
@@ -189,7 +199,7 @@ component
 	}
 
 	/**
-	 * This method is called once a two factor challenge is accepted and valid. 
+	 * This method is called once a two factor challenge is accepted and valid.
 	 * Meaning the user has completed the validation and will be logged in to ContentBox now.
 	 *
 	 * @code The verification code

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/twofactor/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/twofactor/index.cfm
@@ -3,51 +3,53 @@
     <div class="col-md-4" id="login-wrapper">
 
         <div class="panel panel-primary animated fadeInDown">
-        
+
             <div class="panel-heading">
-                <h3 class="panel-title">     
+                <h3 class="panel-title">
                    <i class="fa fa-mobile fa-lg"></i> Two-Factor Authentication
-                </h3>      
+                </h3>
             </div>
-        
+
             <div class="panel-body">
 	        	<!--- Render Messagebox --->
 				#getModel( "messagebox@cbMessagebox" ).renderit()#
 
                 #html.startForm(
-                	action		= prc.xehValidate, 
+                	action		= prc.xehValidate,
                 	ssl 		= event.isSSL(),
-                	name		= "twofactorForm", 
-                	novalidate	= "novalidate", 
+                	name		= "twofactorForm",
+                	novalidate	= "novalidate",
                 	class		= "form-horizontal"
                 )#
-					
+
 					<!--- Event --->
 					#announceInterception( "cbadmin_beforeTwoFactorForm" )#
 
 					<!--- Challenge Text --->
 					<p>#prc.provider.getVerificationHelp()#</p>
-                	
+
 	                <div class="form-group">
 	                    <div class="col-md-12 controls">
 	                        #html.textfield(
-	                        	name			= "twofactorcode", 
-	                        	required		= "required", 
-	                        	class			= "form-control", 
+	                        	name			= "twofactorcode",
+	                        	required		= "required",
+	                        	class			= "form-control",
 	                        	autocomplete	= "off"
 	                        )#
 	                        <i class="fa fa-lock"></i>
 	                    </div>
 	                </div>
 
-					<div class="checkbox">
-					    <label>
-					    	<input type="checkbox" name="trustDevice" id="trustDevice" value="true"> #cb.r( "twofactor.trust@security" )#
-					    	<cfif prc.cbSettings.cb_security_2factorAuth_trusted_days gt 0>
-							(#prc.cbSettings.cb_security_2factorAuth_trusted_days# #cb.r( "common.days@security" )#)
-					    	</cfif>
-					    </label>
-					</div>
+                    <cfif event.getPrivateValue( "showTrustedDeviceCheckbox", true )>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="trustDevice" id="trustDevice" value="true"> #cb.r( "twofactor.trust@security" )#
+                                <cfif prc.cbSettings.cb_security_2factorAuth_trusted_days gt 0>
+                                (#prc.cbSettings.cb_security_2factorAuth_trusted_days# #cb.r( "common.days@security" )#)
+                                </cfif>
+                            </label>
+                        </div>
+                    </cfif>
 
 					<p>&nbsp;</p>
 
@@ -58,10 +60,10 @@
 	                   		</button>
 	                    </div>
 	                </div>
-					
+
 	                <a href="#event.buildLink( prc.xehResend )#">
                			<i class="fa fa-repeat"></i> #cb.r( "twofactor.resendcode@security" )#
-               		</a> 
+               		</a>
 
 	                <!--- Event --->
 					#announceInterception( "cbadmin_afterTwoFactorForm" )#

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/twofactor/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/twofactor/index.cfm
@@ -40,16 +40,14 @@
 	                    </div>
 	                </div>
 
-                    <cfif event.getPrivateValue( "showTrustedDeviceCheckbox", true )>
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" name="trustDevice" id="trustDevice" value="true"> #cb.r( "twofactor.trust@security" )#
-                                <cfif prc.cbSettings.cb_security_2factorAuth_trusted_days gt 0>
-                                (#prc.cbSettings.cb_security_2factorAuth_trusted_days# #cb.r( "common.days@security" )#)
-                                </cfif>
-                            </label>
-                        </div>
-                    </cfif>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="trustDevice" id="trustDevice" value="true"> #cb.r( "twofactor.trust@security" )#
+                            <cfif prc.cbSettings.cb_security_2factorAuth_trusted_days gt 0>
+                            (#prc.cbSettings.cb_security_2factorAuth_trusted_days# #cb.r( "common.days@security" )#)
+                            </cfif>
+                        </label>
+                    </div>
 
 					<p>&nbsp;</p>
 

--- a/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
@@ -45,9 +45,18 @@
 			<!--- Provider Setup Help --->
 			<div class="form-group">
 				<label>Provider Instructions: </label><br>
-				#prc.twoFactorProvider.getAuthorSetupHelp()#
-			</div>
+				#prc.twoFactorProvider.getAuthorSetupHelp( prc.author )#
+            </div>
 
+            <!--- Provider Setup Help --->
+            <cfif len( prc.twoFactorProvider.getAuthorSetupForm( prc.author ) )>
+                <label>Required Provider Information: </label><br>
+                <div class="panel panel-default">
+                    <div class="panel-body">
+                        #prc.twoFactorProvider.getAuthorSetupForm( prc.author )#
+                    </div>
+                </div>
+            </cfif>
 			<!--- Provider Author Options --->
 			<cfif len( prc.twoFactorProvider.getAuthorOptions() )>
                 <div class="form-group">

--- a/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
@@ -3,27 +3,26 @@
 	<!--- AuthorForm --->
 	#html.startForm(
 		name 		= "twofactorForm",
-		action 		= prc.xehSaveTwoFactor,
+		action 		= prc.author.getIs2FactorAuth() ? prc.xehUnenrollTwoFactor : prc.xehEnrollTwoFactor,
 		novalidate 	= "novalidate",
 		class 		= "form-vertical"
 	)#
 		#html.hiddenField( name="authorID", bind=prc.author )#
-		
+
 		<fieldset>
 			<legend>Two-Factor Authentication</legend>
-			
+
 			<p>
 				Increase your account's security by enabling Two-Factor Authentication (2FA).
 			</p>
 
 			<!--- Global Force --->
 			<cfif prc.cbSettings.cb_security_2factorAuth_force>
-			<div class="alert alert-warning">
-				<i class="fa fa-exclamation-triangle fa-lg"></i>
-				Global Two Factor Authentication is currently being enforced. Please make sure that you have setup 
-				your device using the two factor provider shown below.
-			</div>
-
+                <div class="alert alert-warning">
+                    <i class="fa fa-exclamation-triangle fa-lg"></i>
+                    Global Two Factor Authentication is currently being enforced. Please make sure that you have setup
+                    your device using the two factor provider shown below.
+                </div>
 			<!--- Else User can choose to activate it --->
 			<cfelse>
 				<div class="form-group">
@@ -31,28 +30,18 @@
 						class   = "control-label",
 						field   = "is2FactorAuth",
 						content = "Status:"
-					)#
+                    )#
 
-					<div class="controls">
-						#html.checkbox(
-							name    = "is2FactorAuth_toggle",
-							data	= { toggle: 'toggle', match: 'is2FactorAuth' },
-							checked = prc.author.getIs2FactorAuth()
-						)#
-						#html.hiddenField(
-							name	= "is2FactorAuth",
-							bind 	= prc.author
-						)#
-					</div>
+                    #prc.author.getIs2FactorAuth() ? "Enrolled" : "Not Enrolled"#
 				</div>
 			</cfif>
-			
+
 			<!--- Provider Name --->
 			<div class="form-group">
-				<label>Provider: </label> 
+				<label>Provider: </label>
 				<span class="label label-info">#prc.twoFactorProvider.getDisplayName()#</span><br/>
 			</div>
-			
+
 			<!--- Provider Setup Help --->
 			<div class="form-group">
 				<label>Provider Instructions: </label><br>
@@ -61,24 +50,38 @@
 
 			<!--- Provider Author Options --->
 			<cfif len( prc.twoFactorProvider.getAuthorOptions() )>
-			<div class="form-group">
-				<label>Provider Options: </label><br>
-				#prc.twoFactorProvider.getAuthorOptions()#
-			</div>
-			</cfif>
-			
+                <div class="form-group">
+                    <label>Provider Options: </label><br>
+                    #prc.twoFactorProvider.getAuthorOptions()#
+                </div>
+            </cfif>
+
 			<!--- Provider Listener so they can add even more options via events --->
 			#announceInterception( "cbadmin_onAuthorTwoFactorOptions" )#
 
 		</fieldset>
 
-		<!--- 
-			Action Bar 
+		<!---
+			Action Bar
 			Saving only if you have permissions, else it is view only.
 		--->
 		<cfif prc.oCurrentAuthor.checkPermission( "AUTHOR_ADMIN" ) OR prc.author.getAuthorID() EQ prc.oCurrentAuthor.getAuthorID()>
-		<div class="form-actions">
-			<input type="submit" value="Save Details" class="btn btn-danger">
+        <div class="form-actions">
+            <div class="form-group">
+                <cfif prc.author.getIs2FactorAuth()>
+                    #html.button(
+                        type = "submit",
+                        value = "Un-enroll",
+                        class = "btn btn-danger"
+                    )#
+                <cfelse>
+                    #html.button(
+                        type = "submit",
+                        value = "Enroll",
+                        class = "btn btn-primary"
+                    )#
+                </cfif>
+            </div>
 		</div>
 		</cfif>
 

--- a/modules/contentbox/modules/contentbox-admin/views/settings/sections/loginOptions.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/settings/sections/loginOptions.cfm
@@ -5,10 +5,10 @@
 
 	<!--- Global Two Factor Auth --->
 	<div class="form-group">
-        #html.label( 
-        	class   = "control-label", 
-        	field   = "cb_security_2factorAuth_force", 
-        	content = "Force 2 Factor Authentication" 
+        #html.label(
+        	class   = "control-label",
+        	field   = "cb_security_2factorAuth_force",
+        	content = "Force 2 Factor Authentication"
         )#
         <div class="controls">
             <small>Require all users to setup Two-factor authentication.</small><br/><br />
@@ -24,7 +24,7 @@
 			)#
         </div>
     </div>
-	
+
 	<!--- Trusted Device Length --->
 	<div class="form-group">
 		<label class="control-label" for="cb_security_2factorAuth_trusted_days">
@@ -57,17 +57,19 @@
 		<label class="control-label" for="cb_security_2factorAuth_provider">Default Two Factor Provider:</label>
 		<div class="controls">
 			<small>Choose the default two factor provider that will be used for authentication by all ContentBox users. Please note that each provider could have different setup options. Ultimately, refer to the provider documentation.</small><br/>
+            <small class="text-danger"><strong>Note:</strong> Changing the default two factor provider will unenroll all currently enrolled users!</small><br />
 			#html.select(
-				name            = "cb_security_2factorAuth_provider", 
+                name            = "cb_security_2factorAuth_provider",
 				options         = prc.twoFactorProviders,
 				column          = "name",
 				nameColumn      = "displayName",
 				class           = "form-control input-sm",
 				selectedValue   = prc.cbSettings.cb_security_2factorAuth_provider
-			)#
+            )#
+            <br />
 		</div>
 	</div>
-	
+
 	<!--- Event for Two Factor Modules to Add their settings here --->
 	#announceInterception( "cbadmin_onTwoFactorSettingsPanel" )#
 
@@ -112,6 +114,6 @@
 			)#
 		</div>
 	</div>
-	
+
 </fieldset>
 </cfoutput>

--- a/modules/contentbox/modules/contentbox-admin/views/twofactor/forceEnrollment.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/twofactor/forceEnrollment.cfm
@@ -1,0 +1,107 @@
+<cfoutput>
+<div class="container-fluid">
+    <div class="col-md-8" id="login-wrapper">
+        <div class="panel panel-primary animated fadeInDown">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                   <i class="fa fa-key"></i> Enroll in Two Factor Authentication
+                </h3>
+            </div>
+            <div class="panel-body">
+	        	<!--- Render Messagebox. --->
+				#getModel( "messagebox@cbMessagebox" ).renderit()#
+
+                <!--- AuthorForm --->
+                #html.startForm(
+                    name 		= "twofactorForm",
+                    action 		= prc.author.getIs2FactorAuth() ? prc.xehUnenrollTwoFactor : prc.xehEnrollTwoFactor,
+                    novalidate 	= "novalidate",
+                    class 		= "form-vertical"
+                )#
+                    #html.hiddenField( name="authorID", bind=prc.author )#
+
+                    <fieldset>
+                        <!--- Global Force --->
+                        <cfif prc.cbSettings.cb_security_2factorAuth_force>
+                            <div class="alert alert-warning">
+                                <i class="fa fa-exclamation-triangle fa-lg"></i>
+                                Global Two Factor Authentication is currently being enforced. Please make sure that you have setup
+                                your device using the two factor provider shown below.
+                            </div>
+                        <!--- Else User can choose to activate it --->
+                        <cfelse>
+                            <div class="form-group">
+                                #html.label(
+                                    class   = "control-label",
+                                    field   = "is2FactorAuth",
+                                    content = "Status:"
+                                )#
+
+                                #prc.author.getIs2FactorAuth() ? "Enrolled" : "Not Enrolled"#
+                            </div>
+                        </cfif>
+
+                        <!--- Provider Name --->
+                        <div class="form-group">
+                            <label>Provider: </label>
+                            <span class="label label-info">#prc.twoFactorProvider.getDisplayName()#</span><br/>
+                        </div>
+
+                        <!--- Provider Setup Help --->
+                        <div class="form-group">
+                            <label>Provider Instructions: </label><br>
+                            #prc.twoFactorProvider.getAuthorSetupHelp( prc.author )#
+                        </div>
+
+                        <!--- Provider Setup Help --->
+                        <cfif len( prc.twoFactorProvider.getAuthorSetupForm( prc.author ) )>
+                            <label>Required Provider Information: </label><br>
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    #prc.twoFactorProvider.getAuthorSetupForm( prc.author )#
+                                </div>
+                            </div>
+                        </cfif>
+                        <!--- Provider Author Options --->
+                        <cfif len( prc.twoFactorProvider.getAuthorOptions() )>
+                            <div class="form-group">
+                                <label>Provider Options: </label><br>
+                                #prc.twoFactorProvider.getAuthorOptions()#
+                            </div>
+                        </cfif>
+
+                        <!--- Provider Listener so they can add even more options via events --->
+                        #announceInterception( "cbadmin_onAuthorTwoFactorOptions" )#
+
+                    </fieldset>
+
+                    <!---
+                        Action Bar
+                        Saving only if you have permissions, else it is view only.
+                    --->
+                    <cfif prc.oCurrentAuthor.checkPermission( "AUTHOR_ADMIN" ) OR prc.author.getAuthorID() EQ prc.oCurrentAuthor.getAuthorID()>
+                    <div class="form-actions">
+                        <div class="form-group">
+                            <cfif prc.author.getIs2FactorAuth()>
+                                #html.button(
+                                    type = "submit",
+                                    value = "Un-enroll",
+                                    class = "btn btn-danger"
+                                )#
+                            <cfelse>
+                                #html.button(
+                                    type = "submit",
+                                    value = "Enroll",
+                                    class = "btn btn-primary"
+                                )#
+                            </cfif>
+                        </div>
+                    </div>
+                    </cfif>
+
+                #html.endForm()#
+            </div>
+        </div>
+    </div>
+</div>
+</cfoutput>


### PR DESCRIPTION
This pull request improves on the two-factor enrollment flow.

1. Enrollment now requires entering a valid code before two-factor authentication is turned on.

    <img width="761" alt="enroll" src="https://user-images.githubusercontent.com/2583646/34061752-d08818a4-e1a6-11e7-8142-64418d125151.png">
    <img width="1435" alt="voluntary_enrollment" src="https://user-images.githubusercontent.com/2583646/34061723-ae203a80-e1a6-11e7-9464-44e6eb9c5deb.png">
    <img width="767" alt="unenroll" src="https://user-images.githubusercontent.com/2583646/34061736-bfed6c88-e1a6-11e7-8ee6-5f7164b57a1d.png">


2. If global two-factor authentication is on, users will still be able to configure their two-factor settings and enroll in the default provider.  They will not be able to access any other pages.
    
    <img width="1427" alt="force_enrollment" src="https://user-images.githubusercontent.com/2583646/34061680-8b346848-e1a6-11e7-895a-5bfe6336833c.png">

3. Providers can now specify an HTML form to present to the user to configure their profile.  This allows providers to collect the needed user information during forced enrollment.  This will default to the current values for the user, if any.

    <img width="583" alt="required_provider_information" src="https://user-images.githubusercontent.com/2583646/34061808-fe2e87a2-e1a6-11e7-8719-b8ef870c0764.png">


4. Changing the default provider unenrolls all currently enrolled users so they can enroll in the new two-factor authentication provider.

    <img width="1153" alt="automatic_unenrollment" src="https://user-images.githubusercontent.com/2583646/34061845-144fab60-e1a7-11e7-860c-d3a6a835dba8.png">
