### PR TITLE
Forcing users to enroll to MFA when global MFA is ON.

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
@@ -311,7 +311,13 @@ component extends="baseHandler"{
      * Show the two-factor authentication screen for forced enrollment
      */
     function forceTwoFactorEnrollment( event, rc, prc ) {
-        prc.author = prc.oCurrentAuthor;
+		if( flash.exists( "authorData" ) ){
+			// Inflate author for requested events
+			prc.author = authorService.get( flash.get( "authorData" ).authorID );
+		} else {
+			prc.author = prc.oCurrentAuthor;
+		}
+        
         prc.xehEnrollTwoFactor = "#prc.cbAdminEntryPoint#.authors.enrollTwofactor";
         prc.xehUnenrollTwoFactor = "#prc.cbAdminEntryPoint#.authors.unenrollTwoFactor";
         prc.twoFactorProvider = twoFactorService.getDefaultProviderObject();
@@ -332,7 +338,7 @@ component extends="baseHandler"{
         flash.put( "authorID", rc.authorID );
         prc.oAuthor = authorService.get( id=rc.authorID );
 
-        if ( prc.oCurrentAuthor.getAuthorID() != prc.oAuthor.getAuthorID() ) {
+        if ( prc.oCurrentAuthor.isLoaded() && prc.oCurrentAuthor.getAuthorID() != prc.oAuthor.getAuthorID() ) {
             cbMessagebox.warn( "You cannot enroll another user in two-factor authentication." );
             flash.keep();
             setNextEvent(
@@ -354,7 +360,7 @@ component extends="baseHandler"{
         var vResults = validateModel( target = prc.oAuthor, excludes = "password" );
 		if ( vResults.hasErrors() ) {
             cbMessagebox.warn( messageArray=vResults.getAllErrors() );
-            flash.keep( "layout,xehInvalidData,xehEnrollmentSuccess,xehEnrollmentSuccessQueryString" );
+            flash.keep( "layout,xehInvalidData,xehEnrollmentSuccess,xehEnrollmentSuccessQueryString" )
             setNextEvent(
                 event		= flash.get( "xehInvalidData", prc.xehAuthorEditor ),
                 queryString	= "authorID=#prc.oAuthor.getAuthorID()###twofactor"
@@ -438,6 +444,10 @@ component extends="baseHandler"{
 		authorService.saveAuthor( oAuthor );
 		// message
 		cbMessagebox.setMessage( "info","Two Factor Settings Saved!" );
+		if ( !prc.oCurrentAuthor.isLoaded() ){
+			// Set in session, validations are now complete
+			securityService.setAuthorSession( oAuthor );
+		}
 		// relocate
 		setNextEvent(
 			event		= flash.get( "xehEnrollmentSuccess", prc.xehAuthorEditor ),

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/security.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/handlers/security.cfc
@@ -75,6 +75,16 @@ component extends="baseHandler"{
 				);
 			}
 
+			//If Global MFA is turned on and the user is not enrolled to a provider, then force it to enroll
+			if( twoFactorService.isForceTwoFactorAuth() AND !results.author.getIs2FactorAuth() ){
+				flash.put( "authorData", {
+					authorID 	= results.author.getAuthorID(),
+					rememberMe 	= rc.rememberMe,
+					securedURL  = rc._securedURL
+				} );
+				setNextEvent( "#prc.cbAdminEntryPoint#.authors.forceTwoFactorEnrollment" );
+			}
+
 			// Verify if we have to challenge via two factor auth
 			if( twoFactorService.canChallenge( results.author ) ){
 				// Flash data needed for authorizations
@@ -91,7 +101,7 @@ component extends="baseHandler"{
 					messagebox.error( cb.r( "twofactor.error@security" ) );
 				}
 				// Relocate to two factor auth presenter
-				setNextEvent( event	= "#prc.cbAdminEntryPoint#.security.twofactor" );
+				setNextEvent( event	= "#prc.cbAdminEntryPoint#.security.twofactor" ); 
 			}
 
 			// Set keep me log in remember cookie, if set.

--- a/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/editor/twoFactor.cfm
@@ -18,11 +18,11 @@
 
 			<!--- Global Force --->
 			<cfif prc.cbSettings.cb_security_2factorAuth_force>
-                <div class="alert alert-warning">
-                    <i class="fa fa-exclamation-triangle fa-lg"></i>
-                    Global Two Factor Authentication is currently being enforced. Please make sure that you have setup
-                    your device using the two factor provider shown below.
-                </div>
+				<div class="alert alert-warning">
+					<i class="fa fa-exclamation-triangle fa-lg"></i>
+					Global Two Factor Authentication is currently being enforced. Please make sure that you have setup
+					your device using the two factor provider shown below.
+				</div>
 			<!--- Else User can choose to activate it --->
 			<cfelse>
 				<div class="form-group">
@@ -30,9 +30,9 @@
 						class   = "control-label",
 						field   = "is2FactorAuth",
 						content = "Status:"
-                    )#
+					)#
 
-                    #prc.author.getIs2FactorAuth() ? "Enrolled" : "Not Enrolled"#
+					#prc.author.getIs2FactorAuth() ? "Enrolled" : "Not Enrolled"#
 				</div>
 			</cfif>
 
@@ -46,25 +46,24 @@
 			<div class="form-group">
 				<label>Provider Instructions: </label><br>
 				#prc.twoFactorProvider.getAuthorSetupHelp( prc.author )#
-            </div>
+			</div>
 
-            <!--- Provider Setup Help --->
-            <cfif len( prc.twoFactorProvider.getAuthorSetupForm( prc.author ) )>
-                <label>Required Provider Information: </label><br>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        #prc.twoFactorProvider.getAuthorSetupForm( prc.author )#
-                    </div>
-                </div>
+			<!--- Provider Setup Help --->
+			<cfif len( prc.twoFactorProvider.getAuthorSetupForm( prc.author ) )>
+				<label>Required Provider Information: </label><br>
+				<div class="panel panel-default">
+					<div class="panel-body">
+						#prc.twoFactorProvider.getAuthorSetupForm( prc.author )#
+					</div>
+				</div>
 			</cfif>
-			
 			<!--- Provider Author Options --->
 			<cfif len( prc.twoFactorProvider.getAuthorOptions() )>
-                <div class="form-group">
-                    <label>Provider Options: </label><br>
-                    #prc.twoFactorProvider.getAuthorOptions()#
-                </div>
-            </cfif>
+				<div class="form-group">
+					<label>Provider Options: </label><br>
+					#prc.twoFactorProvider.getAuthorOptions()#
+				</div>
+			</cfif>
 
 			<!--- Provider Listener so they can add even more options via events --->
 			#announceInterception( "cbadmin_onAuthorTwoFactorOptions" )#
@@ -76,22 +75,28 @@
 			Saving only if you have permissions, else it is view only.
 		--->
 		<cfif prc.oCurrentAuthor.checkPermission( "AUTHOR_ADMIN" ) OR prc.author.getAuthorID() EQ prc.oCurrentAuthor.getAuthorID()>
-        <div class="form-actions">
-            <div class="form-group">
-                <cfif prc.author.getIs2FactorAuth()>
-                    #html.button(
-                        type = "submit",
-                        value = "Un-enroll",
-                        class = "btn btn-danger"
-                    )#
-                <cfelseif prc.author.getAuthorId() EQ prc.oCurrentAuthor.getAuthorId()>
-                    #html.button(
-                        type = "submit",
-                        value = "Enroll",
-                        class = "btn btn-primary"
-                    )#
-                </cfif>
-            </div>
+		<div class="form-actions">
+			<div class="form-group">
+				<cfif prc.author.getIs2FactorAuth() AND !prc.cbsettings.cb_security_2factorAuth_force>
+					#html.button(
+						type = "submit",
+						value = "Un-enroll",
+						class = "btn btn-danger"
+					)#
+				<cfelseif prc.cbsettings.cb_security_2factorAuth_force>
+					<div class="alert alert-warning">
+						<i class="fa fa-exclamation-triangle fa-lg"></i>
+						You can't un-enroll an user while global MFA is turned on.
+					</div>
+				</cfif>
+				<cfif prc.author.getAuthorId() EQ prc.oCurrentAuthor.getAuthorId() AND !prc.author.getIs2FactorAuth()>
+					#html.button(
+						type = "submit",
+						value = "Enroll",
+						class = "btn btn-primary"
+					)#
+				</cfif>
+			</div>
 		</div>
 		</cfif>
 

--- a/modules/contentbox/modules/contentbox-admin/views/twofactor/forceEnrollment.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/twofactor/forceEnrollment.cfm
@@ -4,12 +4,12 @@
         <div class="panel panel-primary animated fadeInDown">
             <div class="panel-heading">
                 <h3 class="panel-title">
-                   <i class="fa fa-key"></i> Enroll in Two Factor Authentication
+                    <i class="fa fa-key"></i> Enroll in Two Factor Authentication
                 </h3>
             </div>
             <div class="panel-body">
-	        	<!--- Render Messagebox. --->
-				#getModel( "messagebox@cbMessagebox" ).renderit()#
+                <!--- Render Messagebox. --->
+                #getModel( "messagebox@cbMessagebox" ).renderit()#
 
                 <!--- AuthorForm --->
                 #html.startForm(
@@ -79,7 +79,7 @@
                         Action Bar
                         Saving only if you have permissions, else it is view only.
                     --->
-                    <cfif prc.oCurrentAuthor.checkPermission( "AUTHOR_ADMIN" ) OR prc.author.getAuthorID() EQ prc.oCurrentAuthor.getAuthorID()>
+                    <cfif ( !prc.oCurrentAuthor.isLoaded() AND prc.author.isLoaded() ) OR ( prc.author.getAuthorID() EQ prc.oCurrentAuthor.getAuthorID() OR prc.oCurrentAuthor.checkPermission( "AUTHOR_ADMIN" ) )>
                     <div class="form-actions">
                         <div class="form-group">
                             <cfif prc.author.getIs2FactorAuth()>


### PR DESCRIPTION
Admins are not able to un-enroll users from MFA if global MFA setting is turned on.