### PR TITLE
Error clicking Tools --> Export in admin (In CF11)

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
@@ -344,7 +344,36 @@
 								<div class="controls checkbox-spacer">
 									<div class="row">
 										<cfset counter = 1>
-										<cfloop query="prc.widgets">
+										<cfscript>
+											for (w in prc.widgets){
+												if (w.widgettype eq "Custom"){
+													writeOutput('<div class="col-md-6">');
+														try{
+															p = prc.widgetService.getWidget( name=w.name, type=w.widgetType );
+														} catch( Any e ){
+															log.error( 'Error Building #w.toString()#. #e.message# #e.detail#', e );
+															writeOutput( "<div class='alert alert-danger'>Error building '#w.name#' widget: #e.message# #e.detail#</div>" );
+															continue;
+														}
+														writeOutput('<label for="export_widgets_#w.name#" class="checkbox">
+															#html.checkbox(
+																name      	= "export_widgets",
+																id        	= "export_widgets_#w.name#",
+																value 		= "#w.name#",
+																checked 	= true,
+																data  		= { alacarte = true }
+															)# #w.name#
+														</label>
+													</div>');
+													if (counter MOD 2 eq 0){
+														writeOutput('</div>
+														<div class="row">');
+													}
+													counter++;
+												}
+											}
+											</cfscript>
+										<!---<cfloop query="prc.widgets">
 											<cfif prc.widgets.widgettype eq "Custom">
 												<div class="col-md-6">
 													<cfscript>
@@ -372,7 +401,7 @@
 												</cfif>
 												<cfset counter++>
 											</cfif>
-										</cfloop>
+										</cfloop>--->
 									</div>
 								</div>
 							</div>

--- a/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
@@ -373,35 +373,6 @@
 												}
 											}
 											</cfscript>
-										<!---<cfloop query="prc.widgets">
-											<cfif prc.widgets.widgettype eq "Custom">
-												<div class="col-md-6">
-													<cfscript>
-													try{
-														p = prc.widgetService.getWidget( name=prc.widgets.name, type=prc.widgets.widgetType );
-													} catch( Any e ){
-														log.error( 'Error Building #prc.widgets.toString()#. #e.message# #e.detail#', e );
-														writeOutput( "<div class='alert alert-danger'>Error building '#prc.widgets.name#' widget: #e.message# #e.detail#</div>" );
-														continue;
-													}
-													</cfscript>
-													<label for="export_widgets_#prc.widgets.name#" class="checkbox">
-														#html.checkbox(
-															name      	= "export_widgets",
-															id        	= "export_widgets_#prc.widgets.name#",
-															value 		= "#prc.widgets.name#",
-															checked 	= true,
-															data  		= { alacarte = true }
-														)# #prc.widgets.name#
-													</label>
-												</div>
-												<cfif counter MOD 2 eq 0>
-													</div>
-													<div class="row">
-												</cfif>
-												<cfset counter++>
-											</cfif>
-										</cfloop>--->
 									</div>
 								</div>
 							</div>

--- a/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
@@ -344,6 +344,42 @@
 								<div class="controls checkbox-spacer">
 									<div class="row">
 										<cfset counter = 1>
+										<!-- Here is the pull request: https://github.com/Ortus-Solutions/ContentBox/pull/383/-->
+										<!-- Error when clicking Tools -> Export in the admin -->
+										<!-- In CF11 cfloop on query object is not working(query object which is created by using queryNew() function) -->
+										<!-- So, instead of cfloop use for() loop in cfscript. Rewrite the set of code in cfscript, previously some part was written in tags and some was in cfscript. -->
+										<!-- NOTE: Only for CF11 cfloop is not supporting. -->
+										<!-- NOTE: We can revisit the code once CF11 support is dropped. -->
+										<!---<cfloop array="#prc.widgets#" index="w">
+										<cfif w.widgettype eq "Custom">
+											<div class="col-md-6">
+												<cfscript>
+												try{
+													p = prc.widgetService.getWidget( name=w.name, type=w.widgetType );
+												} catch( Any e ){
+													log.error( 'Error Building #w.toString()#. #e.message# #e.detail#', e );
+													writeOutput( "<div class='alert alert-danger'>Error building '#w.name#' widget: #e.message# #e.detail#</div>" );
+													continue;
+												}
+												</cfscript>
+												<label for="export_widgets_#w.name#" class="checkbox">
+													#html.checkbox(
+														name      	= "export_widgets",
+														id        	= "export_widgets_#w.name#",
+														value 		= "#w.name#",
+														checked 	= true,
+														data  		= { alacarte = true }
+													)# #w.name#
+												</label>
+											</div>
+											<cfif counter MOD 2 eq 0>
+												</div>
+												<div class="row">
+											</cfif>
+											<cfset counter++>
+										</cfif>
+										</cfloop>--->
+										<!-- for() loop-->
 										<cfscript>
 											for (w in prc.widgets){
 												if (w.widgettype eq "Custom"){
@@ -372,7 +408,7 @@
 													counter++;
 												}
 											}
-											</cfscript>
+										</cfscript>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
Fixed an error when clicking Tools --> Export in the admin (with CF11 on Ubuntu).
In export.cfm file for looping on widget query (it's a query object created using queryNew() function) cfloop is using. The error is due to the cfloop, so we replaced it from for() loop in cfscript. Here, is the link for more info https://gist.github.com/bennadel/2421037. After applying for() loop, tested the code in CF11, CF2016 and Lucee 5.2.6+60

Here is the ticket link for more error detail: https://ortussolutions.atlassian.net/browse/CONTENTBOX-775

