### PR TITLE
blog paging bootstrap compatable

### DIFF
--- a/modules/contentbox/models/system/CBHelper.cfc
+++ b/modules/contentbox/models/system/CBHelper.cfc
@@ -1501,6 +1501,7 @@ component accessors="true" singleton threadSafe{
 		return prc.oPaging.renderit(
 			foundRows		= prc.entriesCount,
 			link			= prc.pagingLink,
+			aslist			= true,
 			pagingMaxRows	= setting( "cb_paging_maxentries" )
 		);
 	}

--- a/modules/contentbox/models/ui/Paging.cfc
+++ b/modules/contentbox/models/ui/Paging.cfc
@@ -125,19 +125,19 @@ link = The link to use for paging, including a placeholder for the page @page@
 			<cfsavecontent variable="pagingtabs">
 			<cfoutput>
 			<div class="row">
-				<div class="col-xs-6">
+				<div class="col-xs-12">
 					<cfset start = ((currentPage*maxRows)-maxRows)+1>
 					<cfset end = currentPage*maxRows GT foundRows ? foundRows : currentPage*maxRows>
 					<div class="dataTables_info" role="alert" aria-live="polite" aria-relevant="all">Showing #start# to #end# of #arguments.FoundRows# entries (#totalPages# pages)
 					</div>
 				</div>
-				<div class="col-xs-6">
-					<div class="dataTables_paginate paging_simple_numbers">
+				<div class="col-xs-12">
+					
 						<cfif arguments.asList><ul class="pagination"></cfif>
 						
 						<!--- PREVIOUS PAGE --->
 						<cfif currentPage-1 gt 0>
-							<cfif arguments.asList><li class="paginate_button previous" aria-controls="pages" tabindex="0" id="pages_previous"></cfif>
+							<cfif arguments.asList><li class=" previous"  tabindex="0" id="pages_previous"></cfif>
 							<a href="#replace(theLink,"@page@",currentPage-1)#" title="Previous Page">&lt;&lt;</a>
 							<cfif arguments.asList></li></cfif>
 						</cfif>
@@ -146,7 +146,7 @@ link = The link to use for paging, including a placeholder for the page @page@
 						<cfset pageFrom=1>
 						<cfif (currentPage-bandGap) gt 1>
 							<cfset pageFrom=currentPage-bandgap>
-							<cfif arguments.asList><li class="paginate_button" aria-controls="pages" tabindex="0"></cfif>
+							<cfif arguments.asList><li class=""  tabindex="0"></cfif>
 							<a href="#replace(theLink,"@page@",1)#">1</a>
 							<a href="javascript:void(0)">...</a>
 							<cfif arguments.asList></li></cfif>
@@ -158,7 +158,7 @@ link = The link to use for paging, including a placeholder for the page @page@
 							<cfset pageTo=totalPages>
 						</cfif>
 						<cfloop index="pageIndex" from="#pageFrom#" to="#pageTo#">
-							<cfif arguments.asList><li class="paginate_button <cfif currentPage eq pageIndex> active"</cfif>" aria-controls="pages" tabindex="0"></cfif>
+							<cfif arguments.asList><li class="<cfif currentPage eq pageIndex>active"</cfif>"  tabindex="0"></cfif>
 							<a href="#replace(theLink,"@page@",pageIndex)#"
 							   <cfif currentPage eq pageIndex>class="selected active"</cfif>>#pageIndex#</a>
 							<cfif arguments.asList></li></cfif>
@@ -166,7 +166,7 @@ link = The link to use for paging, including a placeholder for the page @page@
 						
 						<!--- End Token --->
 						<cfif (currentPage+bandgap) lt totalPages>
-							<cfif arguments.asList><li class="paginate_button" aria-controls="pages" tabindex="0"></cfif>
+							<cfif arguments.asList><li  tabindex="0"></cfif>
 							<a href="javascript:void(0)">...</a>
 							<a href="#replace(theLink,"@page@",totalPages)#">#totalPages#</a>
 							<cfif arguments.asList></li></cfif>
@@ -174,87 +174,14 @@ link = The link to use for paging, including a placeholder for the page @page@
 						
 						<!--- NEXT PAGE --->
 						<cfif currentPage lt totalPages >
-							<cfif arguments.asList><li class="paginate_button next" aria-controls="pages" tabindex="0" id="pages_next"></cfif>
+							<cfif arguments.asList><li class="next"  tabindex="0" id="pages_next"></cfif>
 							<a href="#replace(theLink,"@page@",currentPage+1)#" title="Next Page">&gt;&gt;</a>
 							<cfif arguments.asList></li></cfif>
 						</cfif>
 						
 						<cfif arguments.asList></ul></cfif>
 					</div>
-					<!---
-					<div class="dataTables_paginate paging_simple_numbers">
-						<cfif arguments.asList><ul class="pagination"></cfif>
-							<li class="paginate_button previous disabled" aria-controls="pages" tabindex="0" id="pages_previous"><a href="#">Previous</a>
-							</li>
-							<li class="paginate_button active" aria-controls="pages" tabindex="0"><a href="#">1</a>
-							</li>
-							<li class="paginate_button next disabled" aria-controls="pages" tabindex="0" id="pages_next"><a href="#">Next</a>
-							</li>
-						</ul>
-					</div>
-					--->
-				</div>
-			</div>	
-			<!---
-			<div class="pagingTabs pagination pagination-small">
-				
-				<div class="pagingTabsTotals">
-					<span class="label label-info">Total Records: #arguments.FoundRows# &nbsp;</span>
-					<span class="label label-info">Total Pages: #totalPages#</span>
-				</div>
-				
-				<div class="pagingTabsCarrousel">
-					<cfif arguments.asList><ul></cfif>
-					
-					<!--- PREVIOUS PAGE --->
-					<cfif currentPage-1 gt 0>
-						<cfif arguments.asList><li></cfif>
-						<a href="#replace(theLink,"@page@",currentPage-1)#" title="Previous Page">&lt;&lt;</a>
-						<cfif arguments.asList></li></cfif>
-					</cfif>
-					
-					<!--- Calcualte PageFrom Carrousel --->
-					<cfset pageFrom=1>
-					<cfif (currentPage-bandGap) gt 1>
-						<cfset pageFrom=currentPage-bandgap>
-						<cfif arguments.asList><li></cfif>
-						<a href="#replace(theLink,"@page@",1)#">1</a>
-						<a href="javascript:void(0)">...</a>
-						<cfif arguments.asList></li></cfif>
-					</cfif>
-					
-					<!--- Page TO of Carrousel --->
-					<cfset pageTo=currentPage+bandgap>
-					<cfif (currentPage+bandgap) gt totalPages>
-						<cfset pageTo=totalPages>
-					</cfif>
-					<cfloop index="pageIndex" from="#pageFrom#" to="#pageTo#">
-						<cfif arguments.asList><li></cfif>
-						<a href="#replace(theLink,"@page@",pageIndex)#"
-						   <cfif currentPage eq pageIndex>class="selected active"</cfif>>#pageIndex#</a>
-						<cfif arguments.asList></li></cfif>
-					</cfloop>
-					
-					<!--- End Token --->
-					<cfif (currentPage+bandgap) lt totalPages>
-						<cfif arguments.asList><li></cfif>
-						<a href="javascript:void(0)">...</a>
-						<a href="#replace(theLink,"@page@",totalPages)#">#totalPages#</a>
-						<cfif arguments.asList></li></cfif>
-					</cfif>
-					
-					<!--- NEXT PAGE --->
-					<cfif currentPage lt totalPages >
-						<cfif arguments.asList><li></cfif>
-						<a href="#replace(theLink,"@page@",currentPage+1)#" title="Next Page">&gt;&gt;</a>
-						<cfif arguments.asList></li></cfif>
-					</cfif>
-					
-					<cfif arguments.asList></ul></cfif>
-				</div>
-									
-			</div>
-			--->
+				</div>	
 			</cfoutput>
 			</cfsavecontent>
 		</cfif>


### PR DESCRIPTION
im wanting to get the bootstrap elements on the blog, but i dont want to interfere with any other use of the paging module.  this only affects when the 'aslist' paramenter is passed with the exception of the col-sm-6 to col-sm12 changes to allow for more room.  this could be changed back for compatibility. 