### PR TITLE
Fixed Lucee 4 Login Issue.

### DIFF
--- a/modules/contentbox/models/security/LoginTracker.cfc
+++ b/modules/contentbox/models/security/LoginTracker.cfc
@@ -49,8 +49,8 @@ component extends="coldbox.system.Interceptor"{
 		var aBlockIPs	 		= loginTrackerService.findAllByValue( realIP );
 		var aBlockUsernames 	= loginTrackerService.findAllByValue( realUsername );
 
-		prc.oBlockByIP	 		= ( aBlockIps.len() ? aBlockIps[ 1 ] : loginTrackerService.new() );
-		prc.oBlockByUsername 	= ( aBlockUsernames.len() ? aBlockUsernames[ 1 ] : loginTrackerService.new() );
+		prc.oBlockByIP	 		= ( arrayLen(aBlockIps) ? aBlockIps[ 1 ] : loginTrackerService.new() );
+		prc.oBlockByUsername 	= ( arrayLen(aBlockUsernames) ? aBlockUsernames[ 1 ] : loginTrackerService.new() );
 
 		// do checks to prevent login
 		var isBlocked = false;


### PR DESCRIPTION
Array.len is not supported in Lucee 4, instead, we need to use arrayLen(array)