### PR TITLE
CONTENTBOX-1084

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
@@ -544,10 +544,10 @@ component{
 			// LOAD Assets
 
 			//injector:css//
-			addAsset( "#prc.fbModRoot#/includes/css/f00ee02d.fb.min.css ");
+			addAsset( "#prc.fbModRoot#/includes/css/f00ee02d.fb.min.css");
 			//endinjector//
 			//injector:js//
-			addAsset( "#prc.fbModRoot#/includes/js/92610417.fb.min.js ");
+			addAsset( "#prc.fbModRoot#/includes/js/92610417.fb.min.js");
 			//endinjector//
 		}
 	}


### PR DESCRIPTION
Remove spaces from fb.min.js filenames to reduce extra characters being added to src.