### PR TITLE
Remove includes folder from Robots txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -4,7 +4,6 @@ Allow: /modules/contentbox/themes/
 Disallow: /coldbox/
 Disallow: /config/
 Disallow: /handlers/
-Disallow: /includes/
 Disallow: /layouts/
 Disallow: /interceptors/
 Disallow: /logs/


### PR DESCRIPTION
This seems to break a lot of things with google.
We need to think about the robots.txt and make it better for general users