### PR TITLE
Fix gruntfile spacing in the FB Assets src

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/Gruntfile.js
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function( grunt ){
 		injector : {
 			options : {
 				transform : function( filepath, index, length ){
-					return 'addAsset( "#prc.fbModRoot#' + filepath + ' ");';
+					return 'addAsset( "#prc.fbModRoot#' + filepath + '");';
 				},
 				starttag : "//injector:{{ext}}//",
 				endtag : "//endinjector//"


### PR DESCRIPTION
Fix gruntfile causing the spacing in the FB Assets src
Related to https://ortussolutions.atlassian.net/browse/CONTENTBOX-1084