### PR TITLE
CONTENTBOX-1085

### DIFF
--- a/modules/contentbox/models/system/Setting.cfc
+++ b/modules/contentbox/models/system/Setting.cfc
@@ -25,7 +25,8 @@ component  	persistent="true"
 				params="{ allocationSize = 1, sequence = 'settingID_seq' }";
 
 	property 	name="name" 
-			 	notnull="true" 
+			 	notnull="true"
+				unique="true"
 				length="100";
 
 	property 	name="value" 
@@ -46,7 +47,7 @@ component  	persistent="true"
 	this.pk = "settingID";
 
 	this.constraints ={
-		"name" 		= { required=true, size="1..100" },
+		"name" 		= { required=true, size="1..100", validator: "UniqueValidator@cborm" },
 		"value" 	= { required=true }
 	};
 


### PR DESCRIPTION
Fixes #1085 
Ensures that the setting name ( slug ) is unique, and cannot be duplicated. 
Without this, if a weird cache race condition is found, the Preflight check would insert 135 duplicate settings, causing every ORM findWhere to return more than 1 record for a setting name, stopping ColdBox from Initiliazing, resulting in many strange and not so wonderful errors. 

https://ortussolutions.atlassian.net/browse/CONTENTBOX-1085