### PR TITLE
Fix content sidebar toggle label

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/views/authors/listPreferences.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/listPreferences.cfm
@@ -100,7 +100,7 @@
 			#html.label(
 				class   = "control-label",
 				field   = "preference.sidebarState",
-				content = "Collapsed Left Navbar:"
+				content = "Show Content Sidebar:"
 			)#
 
 			<div class="controls">


### PR DESCRIPTION
This has been incorrectly labeled for three years. 🤣

See screenshot - the "Show Content Sidebar" setting was changed to "Collapsed Left Navbar", making that a duplicate.

![contentbox-user-settings-double-sidebar-toggle](https://user-images.githubusercontent.com/8106227/82771146-055b8680-9e09-11ea-9a30-08f3f0a19289.png)
