### PR TITLE
Fix ContentBox "latestversion" updater error

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/handlers/autoupdates.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/autoupdates.cfc
@@ -71,7 +71,7 @@ component extends="baseHandler"{
 			prc.entryVersion 	= forgeboxsdk.getLatestVersion( slug=rc.channel );
 
 			// Check if versions are new.
-			prc.updateFound = updateService.isNewVersion( cVersion=prc.contentboxVersion, nVersion=prc.entryVersion.latestVersion.version );
+			prc.updateFound = updateService.isNewVersion( cVersion=prc.contentboxVersion, nVersion=prc.entryVersion.version );
 			// Verify if we have updates?
 			if( prc.updateFound ){
 				cbMessagebox.info( "Woopeee! There is a new ContentBox update for you!" );


### PR DESCRIPTION
It must be that the ForgeBox SDK doesn't return a `latestVersion` struct any more? I don't know, but I was getting this error and just using `entryVersion.version` fixes it. 🤷

See error screenshot.

![Screenshot_2020-05-24 Signature Construction — ContentBox Administrator](https://user-images.githubusercontent.com/8106227/82772691-df84b080-9e0d-11ea-898f-0d78f55497ce.png)
