### PR TITLE
Fix CB admin bar image alignment on tailwind sites

### DIFF
--- a/modules/contentbox/modules/contentbox-ui/views/adminbar/index.cfm
+++ b/modules/contentbox/modules/contentbox-ui/views/adminbar/index.cfm
@@ -216,6 +216,7 @@ body{
 }
 
 ##cb-admin-bar h4 img{
+	display: inline-block;
 	vertical-align: text-bottom;
 	margin-right: 5px;
     margin-bottom: -5px;


### PR DESCRIPTION
Embedding Tailwind in a basic theme will break the admin bar - see screenshot.

![Screenshot_2020-05-26](https://user-images.githubusercontent.com/8106227/82965110-3d8fd000-9f95-11ea-8a1f-2302b51231fb.png)

Tailwind sets `img { display: block; }` by default, which breaks this admin bar. We need to code super defensively for this admin bar, because it can be overriden by all manner of site styles! In the CMS I maintained at one of my old jobs we ended up setting `!important` on every style because we had 200+ websites running this CMS and each one can have different global styles that can break all manner of ContentBox-embedded styles.