### PR TITLE
Encode theme settings in active theme page

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/views/themes/active.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/themes/active.cfm
@@ -4,12 +4,12 @@
 
 		<div class="pull-right">
 	    	<button class="btn btn-success btn-sm"
-	    			onclick="popup( '#event.buildLink( prc.xehPreview )#/l/#prc.activeTheme.name#/h/#hash( prc.oCurrentAuthor.getAuthorID() )#');return false;">
+	    			onclick="popup( '#event.buildLink( prc.xehPreview )#/l/#encodeForJavaScript( prc.activeTheme.name )#/h/#hash( prc.oCurrentAuthor.getAuthorID() )#');return false;">
 				<i class="fa fa-eye"></i> Preview
 			</button>
 		</div>
 
-        <h1 class="h1"><i class="fa fa-picture-o fa-lg"></i> #prc.activeTheme.themeName#</h1>
+        <h1 class="h1"><i class="fa fa-picture-o fa-lg"></i> #encodeForHTML( prc.activeTheme.themeName )#</h1>
     </div>
 </div>
 
@@ -24,32 +24,32 @@
 				<!---screenshot --->
 				<div id="theme-screenshot" class="pull-right">
 					<cfif len( prc.activeTheme.screenShotURL )>
-						<a href="#prc.activeTheme.screenShotURL#" target="_blank">
-							<img src="#prc.activeTheme.screenShotURL#" alt="screenshot" height="200" border="0" class="img-screenshot img-thumbnail"/>
+						<a href="#encodeForHTMLAttribute( prc.activeTheme.screenShotURL )#" target="_blank">
+							<img src="#encodeForHTMLAttribute( prc.activeTheme.screenShotURL )#" alt="screenshot" height="200" border="0" class="img-screenshot img-thumbnail"/>
 						</a>
 						<br/>
 					</cfif>
 				</div>
 
 				<!---Description --->
-				<blockquote id="theme-description">#prc.activeTheme.description#</blockquote>
+				<blockquote id="theme-description">#encodeForHTML( prc.activeTheme.description )#</blockquote>
 				<!---Author --->
 				<div id="theme-author">
 					<i class="fa fa-user"></i>
-					<strong>Author: </strong> <a href="#prc.activeTheme.authorURL#" title="#prc.activeTheme.AuthorURL#" target="_blank">#prc.activeTheme.Author#</a>
+					<strong>Author: </strong> <a href="#encodeForHTMLAttribute( prc.activeTheme.authorURL )#" title="#encodeForHTMLAttribute( prc.activeTheme.AuthorURL )#" target="_blank">#encodeForHTML( prc.activeTheme.Author )#</a>
 				</div>
 				<!--- Version --->
 				<div id="theme-version>">
 					<i class="fa fa-clock-o"></i>
 					<strong>Version: </strong>
-					#prc.activeTheme.version#
+					#encodeForHTML( prc.activeTheme.version )#
 				</div>
 				<!--- ForgeBox Slug --->
 				<div id="theme-forgebox>">
 					<i class="fa fa-cloud-download"></i>
 					<strong>ForgeBox Slug: </strong>
 					<cfif len( prc.activeTheme.forgeboxSlug )>
-						<a href="http://www.coldbox.org/forgebox/view/#prc.activeTheme.forgeboxSlug#">#prc.activeTheme.forgeboxSlug#</a>
+						<a href="http://www.coldbox.org/forgebox/view/#encodeForHTMLAttribute( prc.activeTheme.forgeboxSlug )#">#encodeForHTMLAttribute( prc.activeTheme.forgeboxSlug )#</a>
 					<cfelse>
 						<em>None</em>
 					</cfif>
@@ -59,7 +59,7 @@
 					<i class="fa fa-bullhorn"></i>
 					<strong>Registered Interceptions: </strong>
 					<cfif len( prc.activeTheme.customInterceptionPoints )>
-						#prc.activeTheme.customInterceptionPoints#
+						#encodeForHTML( prc.activeTheme.customInterceptionPoints )#
 					<cfelse>
 						<em>None</em>
 					</cfif>
@@ -69,7 +69,7 @@
 					<i class="fa fa-magic"></i>
 					<strong>Theme Widgets: </strong>
 					<cfif len( prc.activeTheme.widgets )>
-						#prc.activeTheme.widgets#
+						#encodeForHTML( prc.activeTheme.widgets )#
 					<cfelse>
 						<em>None</em>
 					</cfif>
@@ -79,7 +79,7 @@
 					<i class="fa fa-bolt"></i>
 					<strong>Theme Modules: </strong>
 					<cfif len( prc.activeTheme.modules )>
-						#prc.activeTheme.modules#
+						#encodeForHTML( prc.activeTheme.modules )#
 					<cfelse>
 						<em>None</em>
 					</cfif>
@@ -92,7 +92,7 @@
 				<cfif prc.activeTheme.settings.len()>
 					<h1>Theme Settings:</h1>
 					#html.startForm( action=prc.xehSaveSettings, name="layoutSettingsForm" )#
-						#html.hiddenField( name="themeName", value=prc.activeTheme.name )#
+						#html.hiddenField( name="themeName", value=encodeForHTMLAttribute( prc.activeTheme.name ) )#
 
 						<!--- Build out theme settings --->
 						#prc.themeService.buildSettingsForm( prc.activeTheme )#


### PR DESCRIPTION
This PR resolves an issue when viewing the Active Theme page if there is invalid characters in the theme `Author` setting. (See screenshot.)

![Screenshot_2020-05-26 Signature Construction — ContentBox Administrator](https://user-images.githubusercontent.com/8106227/82966728-86e21e80-9f99-11ea-97aa-3c3d002f8653.png)

For example, setting `"Author": "Michael Born <michael@ortussolutions.com>"` will bork the HTML - especially if said author forgets the ending `>` which denotes the end of the email
address. ;)

This PR _may_ introduce compat issues with some themes which expect HTML in the theme description to work wonderfully. (For example.)

For the record, I'm not too concerned with the security implications. (It's a theme, and it's installable. There's probably a lot worse that could happen...) It's just the theme can mangle the Active Theme page, and that's not super cool. And, I suppose, there are indeed security implications.