### PR TITLE
CONTENTBOX-1155 - Add Force Login Rule for Admin Views

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/interceptors/CBRequest.cfc
+++ b/modules/contentbox/modules/contentbox-admin/interceptors/CBRequest.cfc
@@ -90,6 +90,17 @@ component extends="coldbox.system.Interceptor"{
 			return;
 		}
 
+		/************************************** FORCE LOGIN *********************************************/
+
+		if(
+			!findNoCase( "contentbox-security:security", event.getCurrentEvent() )
+			&&
+			!prc.oCurrentAuthor.getLoggedIn()
+		){
+			relocate( "#prc.cbAdminEntryPoint#.security.login" );
+			return;
+		}
+
 		/************************************** NAVIGATION EXIT HANDLERS *********************************************/
 
 		// Global Admin Exit Handlers


### PR DESCRIPTION
CB Admin views are visible even when an admin user is not logged in. This rule forces a login for any view that is not within the security handler