### PR TITLE
fix Mysql 5 driver class/bundle name settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,11 +43,11 @@ MIGRATIONS_BUNDLEVERSION=8.0.19
 ######################################################
 # MySQL 5.7 DB Driver
 ######################################################
-DB_CLASS=com.mysql.cj.jdbc.Driver
+DB_CLASS=com.mysql.jdbc.Driver
 DB_DRIVER=MySQL
 # Lucee Bundle Info: 5.1.40 IS THE ONLY ONE THAT WORKS FOR HIBERNATE
 DB_BUNDLEVERSION=5.1.40
-DB_BUNDLENAME=com.mysql.cj
+DB_BUNDLENAME=com.mysql.jdbc
 # DB Location
 DB_HOST=127.0.0.1
 DB_PORT=3306


### PR DESCRIPTION
Fixes an issue loading the Mysql driver, because ContentBox trying to use the v5 driver but specifying the v8 bundle name and class name.

This breaks the ContentBox DSN creator when installing a new site using `box install contentbox-installer`.