### PR TITLE
ACF2016 and Superclass Updates

### DIFF
--- a/.cfconfig.json
+++ b/.cfconfig.json
@@ -19,7 +19,7 @@
 		}
     },
 	"datasources" : {
-		"${DB_DATABASE}":{
+		"contentbox":{
             "allowAlter":true,
             "allowCreate":true,
             "allowDelete":true,

--- a/modules/contentbox/models/BaseEntityMethods.cfc
+++ b/modules/contentbox/models/BaseEntityMethods.cfc
@@ -6,7 +6,7 @@
  * This is an abstract class that represents base entity methods.
  * We created this due to the stupid bug in ACF 9-2016, where the mapped super class is not respected in table inheritance
  */
-component mappedsuperclass="true" {
+component {
 
 	// PK Pointer
 	this.pk          = "PLEASE_SELECT_ONE";

--- a/modules/contentbox/modules/contentbox-admin/config/Router.cfc
+++ b/modules/contentbox/modules/contentbox-admin/config/Router.cfc
@@ -3,7 +3,7 @@ component {
 	function configure(){
 		route( "/" ).to( "dashboard" );
 
-		route( "/cbsecurity" ).toModuleRouting( "contentbox-security" )
+		route( "/cbsecurity" ).toModuleRouting( "contentbox-security" );
 
 		route( "/authors/page/:page" ).to( "authors" );
 		route( "/comments/page/:page" ).to( "comments" );


### PR DESCRIPTION
The following changes produce no errors on ACF2016.  

Also the DSN name is now hard-coded in the cfconfig file so you can have a database named something other than "contentbox"