### PR TITLE
Feature - Enable Setters on Primary Keys

### DIFF
--- a/modules/contentbox/models/comments/Comment.cfc
+++ b/modules/contentbox/models/comments/Comment.cfc
@@ -35,7 +35,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/content/BaseContent.cfc
+++ b/modules/contentbox/models/content/BaseContent.cfc
@@ -110,7 +110,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/content/Category.cfc
+++ b/modules/contentbox/models/content/Category.cfc
@@ -56,7 +56,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/content/ContentVersion.cfc
+++ b/modules/contentbox/models/content/ContentVersion.cfc
@@ -35,7 +35,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/content/CustomField.cfc
+++ b/modules/contentbox/models/content/CustomField.cfc
@@ -25,7 +25,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/content/Stats.cfc
+++ b/modules/contentbox/models/content/Stats.cfc
@@ -26,7 +26,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/menu/Menu.cfc
+++ b/modules/contentbox/models/menu/Menu.cfc
@@ -44,7 +44,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/menu/item/BaseMenuItem.cfc
+++ b/modules/contentbox/models/menu/item/BaseMenuItem.cfc
@@ -64,7 +64,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/modules/Module.cfc
+++ b/modules/contentbox/models/modules/Module.cfc
@@ -25,7 +25,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/security/Author.cfc
+++ b/modules/contentbox/models/security/Author.cfc
@@ -40,7 +40,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/security/LoginAttempt.cfc
+++ b/modules/contentbox/models/security/LoginAttempt.cfc
@@ -28,7 +28,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	/**

--- a/modules/contentbox/models/security/Permission.cfc
+++ b/modules/contentbox/models/security/Permission.cfc
@@ -25,7 +25,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/security/PermissionGroup.cfc
+++ b/modules/contentbox/models/security/PermissionGroup.cfc
@@ -30,8 +30,6 @@ component
 		fieldtype="id"
 		generator="uuid"
 		length   ="36"
-		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/security/Role.cfc
+++ b/modules/contentbox/models/security/Role.cfc
@@ -34,7 +34,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/security/SecurityRule.cfc
+++ b/modules/contentbox/models/security/SecurityRule.cfc
@@ -25,7 +25,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/subscriptions/BaseSubscription.cfc
+++ b/modules/contentbox/models/subscriptions/BaseSubscription.cfc
@@ -51,7 +51,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	/**

--- a/modules/contentbox/models/subscriptions/Subscriber.cfc
+++ b/modules/contentbox/models/subscriptions/Subscriber.cfc
@@ -25,7 +25,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/system/Setting.cfc
+++ b/modules/contentbox/models/system/Setting.cfc
@@ -27,7 +27,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property

--- a/modules/contentbox/models/system/Site.cfc
+++ b/modules/contentbox/models/system/Site.cfc
@@ -34,7 +34,6 @@ component
 		generator="uuid"
 		length   ="36"
 		ormtype  ="string"
-		setter   ="false"
 		update   ="false";
 
 	property


### PR DESCRIPTION
Remove `setter=false` attributes on PKs to allow imports to use their own PK GUIDs.  `update=false` will still prevent population or override of PK values.