### PR TITLE
Prevent infinite prepend of slug on parent change

### DIFF
--- a/modules/contentbox/models/content/BaseContent.cfc
+++ b/modules/contentbox/models/content/BaseContent.cfc
@@ -1681,7 +1681,7 @@ component
 		if ( isNull( arguments.parent ) ) {
 			variables.parent = javacast( "null", "" );
 			// remove the hierarchical information from our slug if promoting to the root
-			variables.slug = listLast( variables.slug, "/" );
+			variables.slug   = listLast( variables.slug, "/" );
 			return this;
 		} else {
 			// Welcome home papa!
@@ -1695,4 +1695,5 @@ component
 
 		return this;
 	}
+
 }

--- a/modules/contentbox/models/content/BaseContent.cfc
+++ b/modules/contentbox/models/content/BaseContent.cfc
@@ -1680,6 +1680,8 @@ component
 		// Nulllify?
 		if ( isNull( arguments.parent ) ) {
 			variables.parent = javacast( "null", "" );
+			// remove the hierarchical information from our slug if promoting to the root
+			variables.slug = listLast( variables.slug, "/" );
 			return this;
 		} else {
 			// Welcome home papa!
@@ -1688,10 +1690,9 @@ component
 
 		// Update slug, if parent slug is not set
 		if ( !variables.slug.findNoCase( arguments.parent.getSlug() ) ) {
-			variables.slug = arguments.parent.getSlug() & "/" & variables.slug;
+			variables.slug = arguments.parent.getSlug() & "/" & listLast( variables.slug, "/" );
 		}
 
 		return this;
 	}
-
 }

--- a/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
+++ b/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
@@ -182,11 +182,7 @@ component accessors="true" threadSafe singleton {
 			arguments.author.getIs2FactorAuth()
 		) {
 			// Verify if using trusted device options and if device is trusted
-			if (
-				oProvider.allowTrustedDevice() AND isTrustedDevice(
-					arguments.author.getAuthorID()
-				)
-			) {
+			if ( oProvider.allowTrustedDevice() AND isTrustedDevice( arguments.author.getAuthorID() ) ) {
 				results = false;
 			} else {
 				results = true;

--- a/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
+++ b/modules/contentbox/models/security/twofactor/TwoFactorService.cfc
@@ -182,7 +182,11 @@ component accessors="true" threadSafe singleton {
 			arguments.author.getIs2FactorAuth()
 		) {
 			// Verify if using trusted device options and if device is trusted
-			if ( oProvider.allowTrustedDevice() AND isTrustedDevice( arguments.author.getAuthorID() ) ) {
+			if (
+				oProvider.allowTrustedDevice() AND isTrustedDevice(
+					arguments.author.getAuthorID()
+				)
+			) {
 				results = false;
 			} else {
 				results = true;

--- a/modules/contentbox/modules/contentbox-admin/handlers/contentStore.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/contentStore.cfc
@@ -366,18 +366,12 @@ component extends="baseContentHandler" {
 			.paramValue( "content", "" )
 			.paramValue( "customFieldsCount", 0 )
 			.paramValue( "relatedContentIDs", [] )
-			.paramValue( "site", prc.oCurrentSite.getsiteID() );
+			.paramValue( "site", prc.oCurrentSite.getsiteID() )
+			.paramValue( "slug", variables.HTMLHelper.slugify( rc.title ) );
 
 		if ( NOT len( rc.publishedDate ) ) {
 			rc.publishedDate = dateFormat( now() );
 		}
-
-		// slugify the incoming title or slug
-		rc.slug = (
-			NOT len( rc.slug ) ? variables.HTMLHelper.slugify( rc.title ) : variables.HTMLHelper.slugify(
-				listLast( rc.slug, "/" )
-			)
-		);
 
 		// Verify permission for publishing, else save as draft
 		if ( !prc.oCurrentAuthor.checkPermission( "CONTENTSTORE_ADMIN" ) ) {


### PR DESCRIPTION
- On a parent change, the slug needs to be reset to the current hierarchy.  This change ensures that a slug will not be infinitely prepended with previous hierarchy.
- This also removes an unnecessary re-setting of a content store item slug on every save.  Since ContentStore items are not part of a URL hierarchy, and there may be `{{{ContentStore slug='...'}}}` tags in Pages which reference the old slug, there is no need to re-slugify it.