### PR TITLE
Update ContentBoxImporter.cfc

### DIFF
--- a/modules/contentbox/models/importers/ContentBoxImporter.cfc
+++ b/modules/contentbox/models/importers/ContentBoxImporter.cfc
@@ -68,6 +68,10 @@ component accessors=true {
 			var contentBoxPath = variables.moduleSettings[ "contentbox" ].path;
 			var customPath     = variables.moduleSettings[ "contentbox-custom" ].path;
 
+			fileList = fileList.map( function( item ){
+				return item.reReplace( "(\\|\/)", "", "all" );
+			} );
+
 			// now set values
 			setFileNames( fileList );
 			setContentBoxPackagePath( arguments.importFile );
@@ -112,6 +116,7 @@ component accessors=true {
 				overwriteFiles = true
 			);
 			descriptorContents = fileRead( getTempDirectory() & "descriptor.json" );
+			descriptorContents = replaceNoCase( descriptorContents, "null,", "99,", "all" );
 		}
 		return !arguments.asObject ? descriptorContents : deserializeJSON( descriptorContents );
 	}


### PR DESCRIPTION
Resolves issue with Windows and the slashes causing the descriptor.json not to be found. Also addresses an issue in descriptor.json when priority is null. This fix replaces the null value with 99 so that it can be processed.