### PR TITLE
Feature/contentbox 1423 no allow set own parent

### DIFF
--- a/modules/contentbox/models/comments/CommentService.cfc
+++ b/modules/contentbox/models/comments/CommentService.cfc
@@ -285,11 +285,7 @@ component extends="cborm.models.VirtualEntityService" singleton {
 		}
 
 		// Check if user has already an approved comment. If they do, then approve them
-		if (
-			inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment(
-				inComment.getAuthorEmail()
-			)
-		) {
+		if ( inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment( inComment.getAuthorEmail() ) ) {
 			inComment.setIsApproved( true );
 			return true;
 		}

--- a/modules/contentbox/models/comments/CommentService.cfc
+++ b/modules/contentbox/models/comments/CommentService.cfc
@@ -285,7 +285,11 @@ component extends="cborm.models.VirtualEntityService" singleton {
 		}
 
 		// Check if user has already an approved comment. If they do, then approve them
-		if ( inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment( inComment.getAuthorEmail() ) ) {
+		if (
+			inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment(
+				inComment.getAuthorEmail()
+			)
+		) {
 			inComment.setIsApproved( true );
 			return true;
 		}

--- a/modules/contentbox/modules/contentbox-admin/handlers/baseContentHandler.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/baseContentHandler.cfc
@@ -270,12 +270,11 @@ component extends="baseHandler" {
 			);
 		}
 		// Get all content names for parent drop downs excluding yourself and your children
-		prc.allContent = variables.ormService.getAllFlatContent(
-			sortOrder: "slug asc",
-			siteID   : prc.oCurrentSite.getsiteID()
-		).filter( function( item ) {
-			return !reFindNoCase( "#prc.oContent.getSlug()#\/?", arguments.item[ "slug" ] );
-		} );
+		prc.allContent = variables.ormService
+			.getAllFlatContent( sortOrder: "slug asc", siteID: prc.oCurrentSite.getsiteID() )
+			.filter( function( item ){
+				return !reFindNoCase( "#prc.oContent.getSlug()#\/?", arguments.item[ "slug" ] );
+			} );
 		// Get All registered editors so we can display them
 		prc.editors       = variables.editorService.getRegisteredEditorsMap();
 		// Get User's default editor

--- a/modules/contentbox/modules/contentbox-admin/handlers/baseContentHandler.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/baseContentHandler.cfc
@@ -269,11 +269,13 @@ component extends="baseHandler" {
 				eventArguments = { contentID : rc.contentID }
 			);
 		}
-		// Get all content names for parent drop downs
+		// Get all content names for parent drop downs excluding yourself and your children
 		prc.allContent = variables.ormService.getAllFlatContent(
 			sortOrder: "slug asc",
 			siteID   : prc.oCurrentSite.getsiteID()
-		);
+		).filter( function( item ) {
+			return !reFindNoCase( "#prc.oContent.getSlug()#\/?", arguments.item[ "slug" ] );
+		} );
 		// Get All registered editors so we can display them
 		prc.editors       = variables.editorService.getRegisteredEditorsMap();
 		// Get User's default editor

--- a/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
@@ -30,6 +30,12 @@
 							class="form-control input-sm"
 						>
 							<option value="null">- No Parent -</option>
+
+							<!--- Remove the current slug from the options --->
+							<cfset prc.allContent = prc.allContent.filter( function( item ) {
+								return item.findKey( "slug" )[ 1 ].value != prc.oContent.getSlug()
+							} )>
+
 							#html.options(
 								values        : prc.allContent,
 								column        : "contentID",

--- a/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
@@ -31,11 +31,6 @@
 						>
 							<option value="null">- No Parent -</option>
 
-							<!--- Remove the current slug and its children from the options --->
-							<cfset prc.allContent = prc.allContent.filter( function( item ) {
-								return left( item.findKey( "slug" )[ 1 ].value, prc.oContent.getSlug().len() ) != prc.oContent.getSlug()
-							} )>
-
 							#html.options(
 								values        : prc.allContent,
 								column        : "contentID",

--- a/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/_components/editor/sidebar/Modifiers.cfm
@@ -31,9 +31,9 @@
 						>
 							<option value="null">- No Parent -</option>
 
-							<!--- Remove the current slug from the options --->
+							<!--- Remove the current slug and its children from the options --->
 							<cfset prc.allContent = prc.allContent.filter( function( item ) {
-								return item.findKey( "slug" )[ 1 ].value != prc.oContent.getSlug()
+								return left( item.findKey( "slug" )[ 1 ].value, prc.oContent.getSlug().len() ) != prc.oContent.getSlug()
 							} )>
 
 							#html.options(

--- a/modules/contentbox/seeders/BaseSeeder.cfc
+++ b/modules/contentbox/seeders/BaseSeeder.cfc
@@ -1,4 +1,4 @@
-abstract                   component {
+abstract                     component {
 
 	// DI
 	property name="packageService" inject="PackageService";

--- a/modules/contentbox/seeders/BaseSeeder.cfc
+++ b/modules/contentbox/seeders/BaseSeeder.cfc
@@ -1,4 +1,4 @@
-abstract                 component {
+abstract                   component {
 
 	// DI
 	property name="packageService" inject="PackageService";


### PR DESCRIPTION
This will remove the current content slug and any of its children from being allowed to be set as a parent for the item.