### PR TITLE
add modules_user to ORM settings

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -97,7 +97,9 @@ component {
 			// The ContentBox Core Entities
 			"modules/contentbox/models",
 			// Custom Module Entities
-			"modules_app"
+			"modules_app",
+			// Custom Module User Entities
+			"modules/contentbox/modules_user"
 		],
 		// THE DIALECT OF YOUR DATABASE OR LET HIBERNATE FIGURE IT OUT, UP TO YOU TO CONFIGURE.
 		dialect              : request.$systemHelper.getSystemSetting( "ORM_DIALECT", "" ),


### PR DESCRIPTION
I found this issue when I was trying the ContentBox FormBuilder. It was not clear to me as a new ContentBox user why the module wasn't working. In the end, it turned out that modules_user is not currently included in the ormSettings so some contentbox modules on forgebox don't work without Application.cfc being updated by the user.  It was fixed with the help of Michael Born during December'd Office Hours zoom call.

This change resolves the issue I raised. https://ortussolutions.atlassian.net/browse/CONTENTBOX-1453