### PR TITLE
CONTENTBOX-1454 Fix issue in Media Manager where files fail to upload 

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-filebrowser/handlers/Home.cfc
@@ -191,6 +191,7 @@ component extends="cbadmin.handlers.baseHandler" {
 	 */
 	private boolean function isTraversalSecure( required prc, required targetPath ){
 		// Do some cleanup just in case in the incoming root.
+		prc.fbSettings.directoryRoot = cleanIncomingPath(prc.fbSettings.directoryRoot);
 		if ( prc.fbSettings.traversalSecurity AND NOT findNoCase( prc.fbSettings.directoryRoot, arguments.targetPath ) ) {
 			return false;
 		}


### PR DESCRIPTION
Fix issue in Media Manager where files fail to upload with traversal error after server restart on windows.

There is a comment in the file saying "// Do some cleanup just in case in the incoming root." but the cleanup was not being done. After a server restart I found the root on my windows Lucee install had the directories separated by "\\" and was being compared with "/" in several places where it was checking for a traversal error. 

Adding a call to cleanIncomingPath fixes the issue.