### PR TITLE
Sidebar style updates

### DIFF
--- a/modules/contentbox/models/comments/CommentService.cfc
+++ b/modules/contentbox/models/comments/CommentService.cfc
@@ -285,7 +285,11 @@ component extends="cborm.models.VirtualEntityService" singleton {
 		}
 
 		// Check if user has already an approved comment. If they do, then approve them
-		if ( inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment( inComment.getAuthorEmail() ) ) {
+		if (
+			inSettings.cb_comments_moderation_whitelist AND userHasPreviousAcceptedComment(
+				inComment.getAuthorEmail()
+			)
+		) {
 			inComment.setIsApproved( true );
 			return true;
 		}

--- a/modules/contentbox/modules/contentbox-admin/layouts/admin.cfm
+++ b/modules/contentbox/modules/contentbox-admin/layouts/admin.cfm
@@ -31,7 +31,18 @@
 			<!---                               TOP HEADER					                                      --->
 			<!--- ************************************************************************************************--->
 			<header id="header" class="header-default">
-				<div>
+				<div class="flex">
+					<!-- Toggle Navigation Button -->
+					<button
+						class="btn options toggle btn-more sidebar-left-toggle"
+						id="toggle-left"
+						data-toggle="tooltip"
+						data-placement="right"
+						title="Toggle Navigation (Control+Shift+n)"
+						data-keybinding="Control+Shift+n"
+					>
+						#cbAdminComponent( "ui/Icon", { name : "Bars3" } )#
+					</button>
 					<!--Branding-->
 					<div class="brand">
 						<a
@@ -223,17 +234,6 @@
 			<!---                               MAIN NAVBAR					                                      --->
 			<!--- ************************************************************************************************--->
 			<nav class="sidebar sidebar-left" id="main-navbar">
-				<!-- Toggle Navigation Button -->
-				<button
-					class="btn options toggle sidebar-left-toggle"
-					id="toggle-left"
-					data-toggle="tooltip"
-					data-placement="right"
-					title="Toggle Navigation (Control+Shift+n)"
-					data-keybinding="Control+Shift+n"
-				>
-					#cbAdminComponent( "ui/Icon", { name : "Bars3" } )#
-				</button>
 				<!--- Main Generated Menu --->
 				#prc.adminMenuService.generateMenu()#
 			</nav>

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/security/login.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/security/login.cfm
@@ -1,11 +1,11 @@
 ﻿<cfoutput>
 <div>
     <div class="col-md-4" id="login-wrapper">
-		<div class="panel panel-primary animated fadeInDown">
+		<div class="panel animated fadeInDown">
 
             <div class="panel-heading">
-                <h3 class="panel-title p5">
-                   <i class="fa fa-key"></i> Login
+                <h3 class="text-center">
+                   Login
                 </h3>
 			</div>
 
@@ -39,7 +39,7 @@
 	                        	placeholder		= cb.r( "common.username@security" ),
 	                        	autocomplete	= "off"
 	                        )#
-	                        <i class="fa fa-user"></i>
+	                        <i class="fa fa-user" aria-hidden="true"></i>
 	                    </div>
 	                </div>
 	                <div class="form-group">
@@ -51,10 +51,21 @@
 	                        	placeholder		= cb.r( "common.password@security" ),
 	                        	autocomplete	= "off"
 	                        )#
-	                        <i class="fa fa-key"></i>
+	                        <i class="fa fa-key" aria-hidden="true"></i>
 	                    </div>
 
 	                </div>
+
+					<div class="text-right text-sm">
+						<a
+							href="#event.buildLink( prc.xehLostPassword )#"
+							class="help-block"
+						>
+							<i class="fa fa-question-circle"></i>
+							#cb.r( "lostpassword@security" )#?
+						</a>
+					</div>
+
 	                <div class="form-group">
 	                	<div class="col-md-12 controls">
 							<label class="checkbox">
@@ -73,21 +84,11 @@
 					</div>
 
 	                <div class="form-group">
-	                   <div class="col-md-12 text-center">
-	                   		<button type="submit" class="btn btn-primary btn-lg">
+	                   <div class="col-md-offset-3 col-md-6 text-center">
+	                   		<button type="submit" class="btn btn-primary btn-lg btn-block">
 	                   			#cb.r( "common.login@security" )#
 	                   		</button>
 	                    </div>
-					</div>
-
-					<div class="text-right">
-						<a
-							href="#event.buildLink( prc.xehLostPassword )#"
-							class="help-block"
-						>
-							<i class="fa fa-question-circle"></i>
-							#cb.r( "lostpassword@security" )#?
-						</a>
 					</div>
 
 	                <!--- Event --->

--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/security/lostPassword.cfm
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/views/security/lostPassword.cfm
@@ -1,11 +1,11 @@
 ﻿<cfoutput>
 <div>
     <div class="col-md-4" id="login-wrapper">
-        <div class="panel panel-primary animated flipInY">
+        <div class="panel animated flipInY">
 
             <div class="panel-heading">
-                <h3 class="panel-title p5">
-                   <i class="fa fa-key"></i> #cb.r( "lostpassword@security" )#
+                <h3 class="text-center">
+                   #cb.r( "lostpassword@security" )#
                 </h3>
             </div>
 
@@ -37,11 +37,11 @@
                     </div>
 
                     <div class="form-group">
-                       <div class="col-md-12 text-center">
+                       <div class="col-md-offset-3 col-md-6 text-center">
                        		#html.button(
                        			type  = "submit",
                        			value = "#cb.r( "resetpassword@security" )#",
-                       			class = "btn btn-primary btn-lg"
+                       			class = "btn btn-primary btn-lg btn-block"
                        		)#
                         </div>
                     </div>

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/contentbox.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/contentbox.scss
@@ -166,11 +166,6 @@ a.btn.btn-danger:visited {
 .tab-pane .row.well.well-sm {
 	margin: 0 1px 10px;
 }
-/******************** LABELS ****************************/
-
-.label{
-	border-radius: 10px;
-}
 
 /******************** BUTTONS ****************************/
 

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_base.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_base.scss
@@ -5,7 +5,7 @@ html{
  
  body {
     color:$cb-semantic-color-font-base;
-    background: #F1F2F7;
+    background: $cb-semantic-background-color;
     font-family: 'Source Sans Pro',Arial,sans-serif;
     font-size: 1rem;
     font-weight: 400;

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_header.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_header.scss
@@ -18,7 +18,7 @@
           fill: #343434;
         }
         .cb-swirl, .cb-text-box {
-          fill: $cb-semantic-color-fill-primary;
+          fill: $cb-semantic-brand-color-primary;
         }
         .cb-text-content {
           fill: #272727;

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_header.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_header.scss
@@ -44,6 +44,17 @@
         margin: 23px 0 0 20px;
         display: inline-block;
     }
+    .sidebar-left-toggle {
+      background-color: #fff;
+      border: none;
+      box-shadow: none;
+      margin-left: $cb-base-spacer-sm;
+      padding: 0px;
+
+      @media( pointer: coarse ) {
+          opacity:1;
+      }
+  }
     .btn-more {
         background: transparent;
         min-height: 35px;

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_main-content.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_main-content.scss
@@ -8,7 +8,7 @@
     grid-area: main;
     margin-right: 0;
   @include transition(all, .3s,  ease-in-out);
-    background: #f1f2f7;
+    background: transparent;
     min-height: 1000px;
         & #main-content {
         border-top:solid thin #e7e8ec;

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
@@ -56,6 +56,10 @@
                     >a {
                         color: $cb-semantic-color-font-base;
                         font-weight: bold;
+                        
+                        &:hover, &:focus {
+                            color: $cb-component-sidebar-link-color-hover;
+                        }
                     }
                 }
             }

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
@@ -2,7 +2,7 @@
 .sidebar {
     background :$cb-component-sidebar-color-bg;
     min-height: 100%;
-    left: -($cb-base-sidebar-width) + 10px;
+    left: -($cb-base-sidebar-width);
     position: absolute;
     width: $cb-base-sidebar-width;
     @include transition(all, .1s, ease-in-out);

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_sidebars.scss
@@ -20,7 +20,7 @@
             margin-right: $cb-base-spacer-sm;
         }
         .nav-dropdown > .nav-sub {
-            background-color: $cb-semantic-surface-color;
+            background-color: $cb-component-sidebar-subnav-color-bg;;
             display: none;
         }
         .nav-sub {
@@ -31,7 +31,7 @@
             li {
                 position: relative;
                 &::before {
-                    background-color: $cb-semantic-color-neutral-weak;
+                    background-color: $cb-semantic-color-border;
                     border-radius: 50%;
                     content: "";
                     color: #ddd;
@@ -44,7 +44,7 @@
                 }
                 &:hover, &.active, &:focus {
                     &::before {
-                        background-color: $cb-semantic-color-fill-primary;
+                        background-color: $cb-semantic-accent-color;
                     }
                 }
                 >a {
@@ -122,9 +122,9 @@
     text-transform: uppercase;
 }
 .nav .open>a, .nav .open>a:hover, .nav .open>a:focus, .sidebar .nav>li>a:focus {
-    color: $cb-semantic-color-font-base;
-    border-left: solid 4px $cb-semantic-color-primary-weak;
-    background-color: $cb-semantic-color-primary-weak;
+    color: $cb-component-sidebar-link-color-active;
+    border-left: solid 4px $cb-component-sidebar-link-color-bg-active;
+    background-color: $cb-component-sidebar-link-color-bg-active;
 }
 .nav-dropdown {
     > a:after {
@@ -146,6 +146,7 @@
 /******************** SIDEBAR LEFT ****************************/
 .sidebar-left{
 	border-right: 1px solid $cb-semantic-color-border;
+    box-shadow: $cb-base-shadow-sm;
 	grid-area: sidebar;
     padding-right: 10px;
 
@@ -166,7 +167,7 @@
 		> li{
             &:hover {
                 > a {
-                    background-color: $cb-semantic-color-primary-weak;
+                    background-color: $cb-component-sidebar-link-color-bg-hover;
                     color: $cb-component-sidebar-link-color-hover;
                 }
             }
@@ -175,13 +176,13 @@
                 padding-left: $cb-base-spacer-md;
 
                 &:hover, &:focus {
-                    background-color: $cb-semantic-color-primary-weak;
+                    background-color: $cb-component-sidebar-link-color-bg-hover;
                     color: $cb-component-sidebar-link-color-hover;
                 }
 			}
             &.active > a {
-                background-color: $cb-semantic-color-tertiary-weak;
-                border-left: solid 4px $cb-semantic-color-fill-primary;
+                background-color: $cb-component-sidebar-link-color-bg-active;
+                border-left: solid 4px $cb-semantic-accent-color;
 		        color: $cb-component-sidebar-link-color-active;
                 font-weight: bold;
             }
@@ -211,7 +212,7 @@
 }
 .sidebar-left .sidebar-left-toggle {
     background-color: #fff;
-    border-radius: 50%;
+    border-radius: 0px;
     border: 1px solid $cb-semantic-color-border;
     box-shadow: $cb-base-shadow-sm;
     min-height: 30px;
@@ -219,13 +220,12 @@
     opacity:1;
     padding: 0px;
     position: absolute;
-    right: -20px;
-    top: 15px;
-    z-index: 20;
+    right: -30px;
+    top: 0;
+    z-index: 0;
 
     @include breakpoint( lg ) {
-        opacity:0;
-        right: -15px;
+        right: -30px;
     };
     @media( pointer: coarse ) {
         opacity:1;

--- a/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_variables.scss
+++ b/modules/contentbox/modules/contentbox-admin/resources/assets/sass/theme/_variables.scss
@@ -1,15 +1,29 @@
-$cb-base-color-green-kelly-20: #36571a;
-$cb-base-color-green-kelly-40: #6DBE46;
-$cb-base-color-green-kelly-80: #cdecb4;
-$cb-base-color-green-kelly-90: #e6f6d9;
-$cb-base-color-green-kelly-95: #f2fbec; 
+$cb-base-color-green-kelly-95: #ecf8e4;
+$cb-base-color-green-kelly-80: #97d669;
+$cb-base-color-green-kelly-65: #6DBE46;
+$cb-base-color-green-kelly-50: #548f27;
+$cb-base-color-green-kelly-40: #467821;
+$cb-base-color-green-kelly-30: #39611b;
+$cb-base-color-green-kelly-10: #1f350f;
 
-$cb-base-color-teal-10: #0d2a2b;
-$cb-base-color-teal-20: #1a5457;
-$cb-base-color-teal-30: #24767B;
-$cb-base-color-teal-50: #45c6cd;
-$cb-base-color-teal-90: #d9f4f6;
-$cb-base-color-teal-95: #ecfafb; 
+$cb-base-color-midnight-green-95: #eff5f7;
+$cb-base-color-midnight-green-80: #acc9d3;
+$cb-base-color-midnight-green-60: #6a9eb1;
+$cb-base-color-midnight-green-50: #4a89a0;
+$cb-base-color-midnight-green-40: #29758e;
+$cb-base-color-midnight-green-30: #085e7c;
+$cb-base-color-midnight-green-10: #043445;
+
+$cb-base-color-blue-grey-95: #f2f4f6;
+$cb-base-color-blue-grey-90: #d8dde3;
+$cb-base-color-blue-grey-80: #bdc6cf;
+$cb-base-color-blue-grey-70: #a3afbc;
+$cb-base-color-blue-grey-60: #8999aa;
+$cb-base-color-blue-grey-50: #708397;
+$cb-base-color-blue-grey-40: #586e86;
+$cb-base-color-blue-grey-30: #405974;
+$cb-base-color-blue-grey-20: #284563;
+$cb-base-color-blue-grey-10: #1a314a;
 
 $cb-base-color-grey-30: #555454;
 $cb-base-color-grey-40: #717070;
@@ -38,25 +52,37 @@ $cb-base-sidebar-width: 240px;
 $cb-base-sidebarmini-width: 50px;
 
 $cb-semantic-color-neutral-weak: $cb-base-color-grey-90;
-$cb-semantic-color-primary: $cb-base-color-green-kelly-20;
-$cb-semantic-color-primary-light: $cb-base-color-green-kelly-80;
-$cb-semantic-color-primary-weak: $cb-base-color-green-kelly-90;
-$cb-semantic-color-tertiary: $cb-base-color-teal-30;
-$cb-semantic-color-tertiary-weak: $cb-base-color-teal-90;
 
-$cb-semantic-color-fill-primary: $cb-base-color-green-kelly-40;
-$cb-semantic-color-fill-tertiary: $cb-base-color-teal-50;
+$cb-semantic-color-tertiary: $cb-base-color-green-kelly-40;
+$cb-semantic-color-tertiary-light: $cb-base-color-green-kelly-80;
+$cb-semantic-color-tertiary-strong: $cb-base-color-green-kelly-10;
+$cb-semantic-color-tertiary-weak: $cb-base-color-green-kelly-95;
+
+$cb-semantic-color-primary: $cb-base-color-midnight-green-30;
+$cb-semantic-color-primary-light: $cb-base-color-midnight-green-80;
+$cb-semantic-color-primary-strong: $cb-base-color-midnight-green-10;
+$cb-semantic-color-primary-weak: $cb-base-color-midnight-green-95;
+
+$cb-semantic-color-on-tertiary: $cb-base-color-green-kelly-95;
+$cb-semantic-color-on-primary: $cb-base-color-midnight-green-95;
+
+$cb-semantic-color-fill-tertiary: $cb-base-color-green-kelly-65;
+$cb-semantic-color-fill-primary: $cb-base-color-midnight-green-50;
+
+$cb-semantic-brand-color-primary: $cb-base-color-green-kelly-65;
 
 $cb-semantic-color-border: $cb-base-color-grey-80;
 $cb-semantic-color-font-base: $cb-base-color-grey-30;
-$cb-semantic-color-link: $cb-base-color-teal-30;
-$cb-semantic-color-link-hover: $cb-base-color-teal-10;
+$cb-semantic-color-link: $cb-base-color-midnight-green-40;
+$cb-semantic-color-link-hover: $cb-base-color-midnight-green-10;
 
+$cb-semantic-background-color: $cb-base-color-blue-grey-95;
+$cb-semantic-accent-color: $cb-semantic-color-fill-tertiary;
 $cb-semantic-surface-color: $cb-base-color-white; 
 
 $cb-component-button-color-filled-bg-primary: $cb-semantic-color-primary;
 $cb-component-button-color-filled-text-primary: $cb-base-color-white;
-$cb-component-button-color-tinted-bg-primary: $cb-semantic-color-primary-light;
+$cb-component-button-color-tinted-bg-primary: $cb-semantic-color-primary-weak;
 $cb-component-button-color-tinted-text-primary: $cb-semantic-color-primary;
 $cb-component-button-color-outlined-text-primary: $cb-semantic-color-primary;
 $cb-component-button-color-outlined-border-primary: $cb-semantic-color-primary;
@@ -82,20 +108,22 @@ $cb-component-panel-heading-text-transform: none;
 
 $cb-component-tabs-border-radius: $cb-base-radius-no;
 $cb-component-tabs-link-color-active: $cb-semantic-color-font-base;
-$cb-component-tabs-link-border-color-active: $cb-semantic-color-fill-primary;
+$cb-component-tabs-link-border-color-active: $cb-semantic-accent-color;
    
 $cb-component-sidebar-color-bg: $cb-semantic-surface-color;
-$cb-component-sidebar-subnav-color-bg: transparent;
-$cb-component-sidebar-link-color: $cb-semantic-color-link;
-$cb-component-sidebar-link-color-hover: $cb-semantic-color-font-base;
-$cb-component-sidebar-link-color-active: $cb-semantic-color-font-base;
+$cb-component-sidebar-subnav-color-bg: $cb-semantic-background-color;
+$cb-component-sidebar-link-color: $cb-semantic-color-font-base;
+$cb-component-sidebar-link-color-hover: $cb-semantic-color-on-primary;
+$cb-component-sidebar-link-color-bg-hover: $cb-semantic-color-primary-strong;
+$cb-component-sidebar-link-color-bg-active: $cb-semantic-color-primary-strong;
+$cb-component-sidebar-link-color-active: $cb-semantic-color-on-primary;
 
 
    //Colors
    //$defaultColor:#bdc3c7; //grey
    $defaultColor: #a4a8aa;
    $defaultColorHover:lighten($defaultColor,5%); //light grey
-   $primaryColor:#1ABC9C; //turquoise (main app color)
+   $primaryColor: $cb-semantic-color-primary; //turquoise (main app color)
    $primaryColorHover:lighten($primaryColor,5%); //light turquoise (main app hover color)
    $primaryColorLight:lighten($primaryColor,30%); //light turquoise (main app hover color)
    $successColor:#2dcc70; //green

--- a/modules/contentbox/widgets/EntryInclude.cfc
+++ b/modules/contentbox/widgets/EntryInclude.cfc
@@ -28,9 +28,9 @@ component extends="contentbox.models.ui.BaseWidget" singleton {
 	 */
 	any function renderIt( required string slug, string defaultValue ){
 		var entry = entryService.findBySlug(
-			slug = arguments.slug,
+			slug               = arguments.slug,
 			includeUnpublished = false,
-			siteId = getSite().getSiteId()
+			siteId             = getSite().getSiteId()
 		);
 
 		if ( !isNull( entry ) ) {

--- a/modules/contentbox/widgets/Menu.cfc
+++ b/modules/contentbox/widgets/Menu.cfc
@@ -27,10 +27,7 @@ component extends="contentbox.models.ui.BaseWidget" singleton {
 	 * @defaultValue.hint The string to show if the menu does not exist
 	 */
 	any function renderIt( string slug = "EmptyMenuList", string defaultValue ){
-		var menu = menuService.findBySlug(
-			slug = arguments.slug,
-			siteId = getSite().getSiteId()
-		);
+		var menu = menuService.findBySlug( slug = arguments.slug, siteId = getSite().getSiteId() );
 
 		if ( !isNull( menu ) ) {
 			try {

--- a/modules/contentbox/widgets/PageInclude.cfc
+++ b/modules/contentbox/widgets/PageInclude.cfc
@@ -28,9 +28,9 @@ component extends="contentbox.models.ui.BaseWidget" singleton {
 	 */
 	any function renderIt( required string slug, string defaultValue ){
 		var page = pageService.findBySlug(
-			slug = arguments.slug,
+			slug               = arguments.slug,
 			includeUnpublished = false,
-			siteId = getSite().getSiteId()
+			siteId             = getSite().getSiteId()
 		);
 
 		if ( !isNull( page ) ) {


### PR DESCRIPTION
I updated the color palette to have the following key swatches:
![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/fc86e2c6-2b84-4006-b537-32f32f7237d3)

Since the sidebar toggle overlapped one of the menu headings, in mobile view, I moved the toggle to the left of the logo, which is more standard.

![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/7f413f12-3af4-4270-9b87-807901db3dc2)

I did not completely revert the sidebar since there was not enough contrast between the subnav text and its background.  I did however darkened the active and hover states, to use the updated palette.  Compared to the original subnavigation, I lightened the background color.  I kept the subnav bullets but I darkened them.
![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/7d3c67c0-ec09-4bd2-981b-f0e0b6cd43f3)

Hovering over another menu item:
![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/e01a5bbc-b903-49ca-8d88-e44ce1f32b05)

I updated the Login page to have a simpler and cleaner look:
![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/be602127-eebb-435c-a72d-eb974c693049)


 