### PR TITLE
Missing media icons

### DIFF
--- a/modules/contentbox/models/menu/providers/MediaProvider.cfc
+++ b/modules/contentbox/models/menu/providers/MediaProvider.cfc
@@ -27,7 +27,7 @@ component
 	public MediaProvider function init(){
 		setName( "Media" );
 		setType( "Media" );
-		setIconClass( "fa fa-photo" );
+		setIconClass( "fas fa-photo-video" );
 		setEntityName( "cbMediaMenuItem" );
 		setDescription( "A menu item to a media item" );
 		return this;

--- a/modules/contentbox/modules/contentbox-admin/views/menus/providers/media/admin.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/menus/providers/media/admin.cfm
@@ -5,7 +5,7 @@
             <div class="controls">
                 <div class="input-group no-margin">
                     <span class="input-group-addon btn-info select-media">
-                       <i class="fa fa-photo"></i>
+                       <i class="fas fa-photo-video"></i>
                     </span>
                     <input type="hidden" name="mediaPath" class="textfield" required="true" value="#args.menuItem.getMediaPath()#" />
                     <input type="text" name="media" class="form-control" required="true" title="Select a media item" readonly=true value="#args.menuItem.getMediaPath()#" />

--- a/modules/contentbox/modules/contentbox-admin/views/settings/sections/siteOptions.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/settings/sections/siteOptions.cfm
@@ -46,7 +46,7 @@
 
 	<!--- Site Maintenance --->
 	<fieldset>
-	<legend><i class="fa fa-hand-holding-medical fa-lg"></i> <strong>Maintenance</strong></legend>
+	<legend><i class="fas fa-tools fa-lg"></i> <strong>Maintenance</strong></legend>
 		<p>You can put your sites in maintenance mode if you are doing upgrades or anything funky!</p>
 		<!--- Site maintenance --->
 		<div class="form-group">

--- a/modules/contentbox/modules/contentbox-admin/views/settings/sections/siteOptions.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/settings/sections/siteOptions.cfm
@@ -45,8 +45,7 @@
 	</fieldset>
 
 	<!--- Site Maintenance --->
-	<fieldset>
-	<legend><i class="fas fa-tools fa-lg"></i> <strong>Maintenance</strong></legend>
+	<legend><i class="fas fa-hand-holding-medical fa-lg"></i> <strong>Maintenance</strong></legend>
 		<p>You can put your sites in maintenance mode if you are doing upgrades or anything funky!</p>
 		<!--- Site maintenance --->
 		<div class="form-group">

--- a/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/tools/exporter.cfm
@@ -308,7 +308,7 @@
 						<div class="row">
 
 							<div class="col-md-3">
-								<h4><i class="fa fa-photo fa-lg"></i> Themes</h4>
+								<h4><i class="fas fa-photo-video fa-lg"></i> Themes</h4>
 								<div class="checkbox">
 									<label class="checkbox" for="toggle_layouts">
 										#html.checkbox(


### PR DESCRIPTION
Restored the Media icon in the Menu Designer page:
![image](https://github.com/Ortus-Solutions/ContentBox/assets/10825162/91719891-fade-4185-bb8b-4519636bead6)
