### PR TITLE
fix_for_error_when_initailising_custom_module_widget CONTENTBOX-1499

### DIFF
--- a/modules/contentbox/models/ui/WidgetService.cfc
+++ b/modules/contentbox/models/ui/WidgetService.cfc
@@ -134,7 +134,7 @@ component accessors="true" singleton threadSafe {
 			( arguments.type == "Core" ? variables.coreWidgetsPath : variables.customWidgetsPath )
 		);
 
-		// Iterate and incorporate exta metadata to record
+		// Iterate and incorporate extra metadata to record
 		for ( var x = 1; x lte qWidgets.recordCount; x++ ) {
 			var widgetName = ripExtension( qWidgets.name[ x ] );
 			// Add new row with data
@@ -232,7 +232,7 @@ component accessors="true" singleton threadSafe {
 			);
 
 			try {
-				var oWidget = getWidget( widgetName, arguments.type );
+				var oWidget = getWidget( widgetName & "@" & moduleName, "Module" );
 				querySetCell(
 					arguments.qRecords,
 					"category",


### PR DESCRIPTION
When the widget is in a module wirebox fails to find it because the type is marked as 'core' rather than 'module' and the name is wrong because the module name is removed.

Also fixed a spelling mistake in a comment.
