### PR TITLE
Resolve CONTENTBOX-1511

### DIFF
--- a/modules/contentbox/models/system/SettingService.cfc
+++ b/modules/contentbox/models/system/SettingService.cfc
@@ -603,6 +603,7 @@ component
 	 */
 	SettingService function bulkSave( struct memento, site ){
 		var settings    = isNull( arguments.site ) ? getAllSettings() : getAllSiteSettings( arguments.site.getSlug() );
+		var siteId 		= arguments.site ?: javacast( "null", 0 );
 		var newSettings = [];
 
 		arguments.memento
@@ -614,7 +615,7 @@ component
 			.each( function( key, value ){
 				var thisSetting = findWhere( {
 					name : key,
-					site : !isNull( arguments.site ) ? arguments.site : javacast( "null", "" )
+					site : !isNull( siteId ) ? siteId : javacast( "null", "" )
 				} );
 
 				// Maybe it's a new setting :)
@@ -625,8 +626,8 @@ component
 				thisSetting.setValue( toString( value ) );
 
 				// Site mapping
-				if ( !isNull( site ) ) {
-					thisSetting.setSite( site );
+				if ( !isNull( siteId ) ) {
+					thisSetting.setSite( siteId );
 				}
 
 				newSettings.append( thisSetting );


### PR DESCRIPTION
# Description

I created a new variable to increase the scope of site ID variable, in the bulkSave method.
With that, we prevent that the Global HTML option doesn't create a new record and update it instead

## Jira Issues
> Bug Tracker: https://ortussolutions.atlassian.net/browse/CONTENTBOX-1511


## Type of change
- [ x ] Bug Fix