### PR TITLE
Patch/performance fixes

### DIFF
--- a/modules/contentbox/models/content/BaseContent.cfc
+++ b/modules/contentbox/models/content/BaseContent.cfc
@@ -330,8 +330,8 @@ component
 		cfc         ="contentbox.models.content.ContentVersion"
 		orderby     ="version desc"
 		fkcolumn    ="FK_contentID"
-		insert	  = false
-		update = false;
+		insert      =false
+		update      =false;
 
 	// M20 -> Parent Page loaded as a proxy
 	property
@@ -1139,19 +1139,23 @@ component
 
 	/**
 	 * Get the latest active version object, empty new one if none assigned
+	 *
+	 * @asString Default false.  When provided as true, a projection list query to retrieve only the string content will be executed
 	 */
 	any function getActiveContent( asString = false ){
 		// If we don't have any versions, send back a new one
 		if ( !hasActiveContentVersion() ) {
 			return arguments.asString ? "" : variables.contentVersionService.new();
-		} else if( arguments.asString ) {
-			var activeContentStruct =  contentVersionService.newCriteria()
-										.isEq( "relatedContent.contentID", getContentID() )
-										.isEq( "isActive", javacast( "boolean", true ) )
-										.withProjections( property="content" )
-										.asStruct()
-										.order( "version", "desc" )
-										.list( max=1 ).first();
+		} else if ( arguments.asString ) {
+			var activeContentStruct = contentVersionService
+				.newCriteria()
+				.isEq( "relatedContent.contentID", getContentID() )
+				.isEq( "isActive", javacast( "boolean", true ) )
+				.withProjections( property = "content" )
+				.asStruct()
+				.order( "version", "desc" )
+				.list( max = 1 )
+				.first();
 			return activeContentStruct[ "content" ];
 		} else {
 			return getActiveContentVersions().first();

--- a/modules/contentbox/models/content/BaseContent.cfc
+++ b/modules/contentbox/models/content/BaseContent.cfc
@@ -1176,7 +1176,7 @@ component
 	 * Verify if this content object has an active version with content
 	 */
 	boolean function hasActiveContent(){
-		return !isLoaded() || !hasActiveContentVersion();
+		return isLoaded() && hasActiveContentVersion();
 	}
 
 	/**

--- a/modules/contentbox/models/content/ContentVersion.cfc
+++ b/modules/contentbox/models/content/ContentVersion.cfc
@@ -86,7 +86,6 @@ component
 		fieldtype="many-to-one"
 		fkcolumn ="FK_contentID"
 		lazy     ="true"
-		fetch    ="join"
 		index    ="idx_contentVersions";
 
 	/* *********************************************************************


### PR DESCRIPTION
# Description

This PR resolves several performance issues seen in the wild:

* `getActiveContent` has been refactored to allow an `asString` boolean arg.  When passed as `true` this will execute a projection list query to retrieve the content string only.  This is demonstrating a significant performance improvement - especially when ContentStore items contain JSON which is exposed directly from the API
* A read-only `activeContentVersions` property has been added to prevent retrieval of all versions.  This is a significant performance improvement when the content item has a large number of revisions, compared to looping all versions.
* The `fetch="join"` attribute has been removed from the ContentVersion `relatedContent` relationship as this is mutually exclusive to `lazy="true"`  the queries being executed when retrieving content items alone were producing the join, but also the joins from the BaseContent and were significantly increasing version entity retrieval times.

## Type of change

Please delete options that are not relevant.

- [X] Improvement

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
