### PR TITLE
CONTENTBOX-1207 support for author site security

### DIFF
--- a/modules/contentbox/models/security/Author.cfc
+++ b/modules/contentbox/models/security/Author.cfc
@@ -196,6 +196,21 @@ component
 		inversejoincolumn="FK_permissionGroupID"
 		orderby          ="name";
 
+	// M2M -> A-la-carte Author Sites
+	// Added to support Ziblix Site Security
+	property
+		name              = "sites"
+		singularName      = "site"
+		fieldtype         = "many-to-many"
+		type              = "array"
+		lazy              = "true"
+		orderby           = "name"
+		cfc               = "contentbox.models.system.Site"
+		cascade           = "all"
+		linktable         = "cb_authorsite"
+		fkcolumn          = "FK_authorID"
+		inversejoincolumn = "FK_siteID";
+
 	/* *********************************************************************
 	 **							CALCULATED FIELDS
 	 ********************************************************************* */
@@ -455,7 +470,7 @@ component
 	/**
 	 * Remove both sides of this relationship: PermissionGroup <-> Author
 	 *
-	 * @group The permission group to add
+	 * @group The permission group to remove
 	 */
 	Author function removePermissionGroup( required group ){
 		// Only add if not already there.

--- a/modules/contentbox/models/security/AuthorService.cfc
+++ b/modules/contentbox/models/security/AuthorService.cfc
@@ -232,6 +232,7 @@ component
 	 * @sortOrder        The sort order to apply
 	 * @permissionGroups Single or list of permissiong groups to search on
 	 * @twoFactorAuth    Two factor auth or any
+	 * @siteList         a comma separated list of site IDs
 	 *
 	 * @return {authors:array, count:numeric}
 	 */
@@ -244,7 +245,8 @@ component
 		boolean asQuery  = false,
 		string sortOrder = "lastName",
 		string permissionGroups,
-		string twoFactorAuth
+		string twoFactorAuth,
+		string siteList = ""
 	){
 		var results = { "count" : 0, "authors" : [] };
 		var c       = newCriteria();

--- a/modules/contentbox/models/system/SettingService.cfc
+++ b/modules/contentbox/models/system/SettingService.cfc
@@ -77,6 +77,8 @@ component
 		"cb_security_2factorAuth_trusted_days"  : "30",
 		"cb_security_login_signout_url"         : "",
 		"cb_security_login_signin_text"         : "",
+		"cb_security_limit_sites_by_author"     : "false",
+		"cb_security_all_sites_permission"      : "_ALL_SITES",
 		// Admin settings
 		"cb_admin_ssl"                          : "false",
 		"cb_admin_quicksearch_max"              : "5",

--- a/modules/contentbox/models/system/Site.cfc
+++ b/modules/contentbox/models/system/Site.cfc
@@ -278,8 +278,24 @@ component
 		inverse     ="true"
 		cascade     ="all-delete-orphan";
 
+	// M2M -> authors
+	// Added to support Site Security
+	property
+		name              = "authors"
+		singularName      = "author"
+		fieldtype         = "many-to-many"
+		type              = "array"
+		lazy              = "true"
+		orderby           = "name"
+		cfc               = "contentbox.models.security.Author"
+		cascade           = "all"
+		linktable         = "cb_authorsite"
+		fkcolumn          = "FK_siteID"
+		inversejoincolumn = "FK_authorID"
+		inverse           = "true";
+
 	/* *********************************************************************
-	 **							CALUCLATED FIELDS
+	 **							CALCULATED FIELDS
 	 ********************************************************************* */
 
 	property
@@ -355,7 +371,8 @@ component
 			"entries",
 			"menus",
 			"pages",
-			"settings"
+			"settings",
+			"authors"
 		],
 		profiles : {
 			export : {
@@ -365,7 +382,8 @@ component
 					"entries",
 					"menus",
 					"pages",
-					"settings"
+					"settings",
+					"authors"
 				],
 				defaultExcludes : [
 					"settings.siteSnapshot",

--- a/modules/contentbox/models/system/SiteService.cfc
+++ b/modules/contentbox/models/system/SiteService.cfc
@@ -210,6 +210,41 @@ component
 	}
 
 	/**
+	 * Site Security
+	 * Get an array/struct representation of sites available to the current user [ON site.siteID = author.FK_siteID]
+	 *
+	 * @authorId the author to get the authorised sites for
+	 * @isActive If passed, bind via this boolean flag 
+	 *
+	 * @return array of { siteID, name, slug, domainRegex, domainAliases, isActive }
+	 */
+	array function getAuthorSitesFlat( required string authorID, boolean isActive ){
+		return executeQuery(
+			query: "
+				SELECT site.siteID,
+				       site.name,
+				       site.slug,
+				       site.domainRegex,
+				       site.domainAliases,
+				       site.isActive
+				FROM cbSite site JOIN site.authors authors  
+				WHERE authors.authorID = :authorID
+			",
+			params: { "authorID" : arguments.authorID }
+			
+		).map(function(row) {
+			return {
+				"siteID": row[1],
+				"name": row[2],
+				"slug": row[3],
+				"domainRegex": row[4],
+				"domainAliases": row[5],
+			    "isActive": row[6]
+			};
+		});
+	}
+
+	/**
 	 * Returns a collection of all the themes that are used in all active sites
 	 *
 	 * @return array of { activeTheme:string, siteID:numeric }

--- a/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
+++ b/modules/contentbox/modules/contentbox-admin/handlers/authors.cfc
@@ -124,7 +124,8 @@ component extends="baseHandler" {
 			.paramValue( "f2FactorAuth", "true" )
 			.paramValue( "fRole", "any" )
 			.paramValue( "fGroups", "any" )
-			.paramValue( "sortOrder", "lastname_asc" );
+			.paramValue( "sortOrder", "lastname_asc" )
+			.paramValue( "siteList", "" );
 
 		// prepare paging object
 		prc.oPaging    = variables.paging;
@@ -189,7 +190,8 @@ component extends="baseHandler" {
 			isActive         = rc.fStatus,
 			role             = rc.fRole,
 			permissionGroups = rc.fGroups,
-			twoFactorAuth    = rc.f2FactorAuth
+			twoFactorAuth    = rc.f2FactorAuth,
+			siteList         = rc.siteList
 		);
 		prc.authors     = results.authors;
 		prc.authorCount = results.count;
@@ -633,6 +635,8 @@ component extends="baseHandler" {
 		prc.xehRolePermissions  = "#prc.cbAdminEntryPoint#.authors.permissions";
 		prc.xehGroupRemove      = "#prc.cbAdminEntryPoint#.authors.removePermissionGroup";
 		prc.xehGroupSave        = "#prc.cbAdminEntryPoint#.authors.savePermissionGroup";
+		prc.xehSiteRemove       = "#prc.cbAdminEntryPoint#.authors.removeSite";
+		prc.xehSiteSave         = "#prc.cbAdminEntryPoint#.authors.saveSite";
 
 		// Get all permissions
 		prc.aPermissions      = permissionService.list( sortOrder = "permission", asQuery = false );
@@ -711,6 +715,46 @@ component extends="baseHandler" {
 		if ( oAuthor.hasPermissionGroup( oGroup ) ) {
 			// Remove it
 			oAuthor.removePermissionGroup( oGroup );
+			// Save it
+			variables.authorService.save( oAuthor );
+		}
+
+		// Saved
+		event.renderData( data = "true", type = "json" );
+	}
+
+	/**
+	 * Save sites to the author and gracefully end.
+	 *
+	 * @return json
+	 */
+	function saveSite( event, rc, prc ){
+		var oAuthor = authorService.get( rc.authorID );
+		var oSite   = siteService.get( rc.siteID );
+
+		// Assign it
+		if ( !oAuthor.hasSite( oSite ) ) {
+			oAuthor.addSite( oSite );
+			// Save it
+			variables.authorService.save( oAuthor );
+		}
+
+		// Saved
+		event.renderData( data = "true", type = "json" );
+	}
+
+	/**
+	 * Remove sites to a author and gracefully end.
+	 *
+	 * @return json
+	 */
+	function removeSite( event, rc, prc ){
+		var oAuthor = authorService.get( rc.authorID );
+		var oSite   = siteService.get( rc.siteID );
+
+		if ( oAuthor.hasSite( oSite ) ) {
+			// Remove it
+			oAuthor.removeSite( oSite );
 			// Save it
 			variables.authorService.save( oAuthor );
 		}

--- a/modules/contentbox/modules/contentbox-admin/interceptors/CBRequest.cfc
+++ b/modules/contentbox/modules/contentbox-admin/interceptors/CBRequest.cfc
@@ -51,13 +51,21 @@ component extends="coldbox.system.Interceptor" {
 		} else {
 			prc.cbEntryPoint = "";
 		}
-		// Place all sites in prc for usage by the UI switcher
-		prc.allSites         = variables.siteService.getAllFlat( isActive: true );
+
 		// Get the current working site object on PRC
 		prc.oCurrentSite     = variables.siteService.getCurrentWorkingSite();
 		// Place global cb options on scope
 		prc.cbSettings       = variables.settingService.getAllSettings();
 		prc.cbSiteSettings   = variables.settingService.getAllSiteSettings( prc.oCurrentSite.getSlug() );
+
+		// Place all sites in prc for usage by the UI switcher
+		prc.allSites         = variables.siteService.getAllFlat( isActive: true );
+
+		// If we are limiting sites by author get the list of sites allowed for this author
+		if ( prc.cbSettings.cb_security_limit_sites_by_author ?: false and len( prc.oCurrentAuthor.getAuthorID() )){
+			prc.authorSites  = variables.siteService.getAuthorSitesFlat( authorID: prc.oCurrentAuthor.getAuthorID(), isActive: true );
+		}
+
 		// Place widgets root location
 		prc.cbWidgetRoot     = getContextRoot() & event.getModuleRoot( "contentbox" ) & "/widgets";
 		// store admin menu service

--- a/modules/contentbox/modules/contentbox-admin/layouts/admin.cfm
+++ b/modules/contentbox/modules/contentbox-admin/layouts/admin.cfm
@@ -115,6 +115,15 @@
 					</div>
 
 					<!-- Site Switcher -->
+					<!--- support security by site --->
+					<cfif prc.oCurrentAuthor.hasPermission( "_ALL_SITES" )>
+						<cfset siteListName = "allSites">
+					<cfelse>
+						<cfset siteListName = "authorSites">
+					</cfif>
+
+					<cfif structKeyExists(prc, siteListName) AND arrayLen(prc[siteListName])>
+						<cfset siteOK = false>
 					<span
 						class="form-inline ml10 mt10"
 						id="div-siteswitcher"
@@ -130,7 +139,9 @@
 							onChange="to( '#event.buildLink( prc.xehChangeSite )#/siteID/' + this.value )"
 							style="width: 175px;"
 						>
-							<cfloop array="#prc.allSites#" index="thisSite">
+						
+							<cfloop array="#prc[siteListName]#" index="thisSite">
+								<cfif thisSite[ 'siteID' ] eq prc.oCurrentSite.getsiteID()><cfset siteOK = true></cfif>
 								<option
 									value="#thisSite[ 'siteID' ]#"
 									<cfif thisSite[ 'siteID' ] eq prc.oCurrentSite.getsiteID()>selected="selected"</cfif>
@@ -140,6 +151,15 @@
 							</cfloop>
 						</select>
 					</span>
+						<!--- if the user is not allowed to edit this site redirect to the first valid site  --->
+						<cfif NOT siteOK>
+							<cflocation url="#event.buildLink( prc.xehChangeSite )#/siteID/#prc[siteListName][1].siteID#">
+						</cfif>
+					<cfelse>
+						<!--- if the user does not have any authorised sites redirect to site home page --->
+						<cflocation url="/" >
+					</cfif>
+					<!--- End of Code updated to support ziblix security by site --->
 
 					<!---Search --->
 					<cfif prc.oCurrentAuthor.hasPermission( "GLOBAL_SEARCH" )>

--- a/modules/contentbox/modules/contentbox-admin/views/authors/editorHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/editorHelper.cfm
@@ -83,8 +83,9 @@ document.addEventListener( "DOMContentLoaded", () => {
 			'Passwords need to match'
 		);
 
-		// Setup Permissions
+		// Setup Permissions and Sites
 		$permissions = $( "##permissions" );
+		$sites       = $( "##sites" );
 	</cfif>
 
 	// Password change rules

--- a/modules/contentbox/modules/contentbox-admin/views/authors/index.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/index.cfm
@@ -27,7 +27,7 @@
 					<div class="row">
 
 						<!--- Quick Search --->
-						<div class="col-md-6 col-xs-4">
+						<div class="col-md-3 col-xs-3">
 							<div class="form-group form-inline no-margin">
 								#html.textField(
 									name 		= "userSearch",

--- a/modules/contentbox/modules/contentbox-admin/views/authors/permissions.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/permissions.cfm
@@ -129,7 +129,7 @@
 	<!--- Add Permission Form--->
 	#html.startForm( name="permissionForm", class="form-vertical" )#
 	#html.startFieldset( legend="A-la-Carte Permissions" )#
-	<cfif prc.oCurrentAuthor.hasPermission( "AUTHOR_ADMIN" )>
+		<cfif prc.oCurrentAuthor.hasPermission( "AUTHOR_ADMIN" )>
 			#html.hiddenField( name="authorID", bind=prc.author )#
 
 			<!--- Loader --->
@@ -182,7 +182,7 @@
 				</div>
 
 			</div>
-			</div>
+		</div>
 	</cfif>
 	#html.endFieldSet()#
 	#html.endForm()#
@@ -209,5 +209,86 @@
 
 	#html.endForm()#
 
-</div>
+	<cfif prc.cbSettings.cb_security_limit_sites_by_author>
+		<cfif prc.author.hasPermission( prc.cbSettings.cb_security_all_sites_permission )>
+			<p><div class="alert alert-info">This user has the overiding '#prc.cbSettings.cb_security_all_sites_permission#' permission assigned!</div></p>
+		<cfelse>
+			<!--- Site Selection Form --->
+			#html.startForm( name="siteForm", class="form-vertical" )#
+			#html.startFieldset( legend="Site Assignments" )#
+				<cfif prc.oCurrentAuthor.hasPermission( "AUTHOR_ADMIN" )>
+					<!--- Loader --->
+					<div class="loaders float-right text-center" id="siteLoader">
+						<i class="fa fa-circle-o-notch fa-spin fa-lg"></i><br/>
+						<div class="text-center"><small>Please Wait...</small></div>
+					</div>
+
+					<!--- Sites --->
+					<p>You can assign sites to the user by adding from the selection below:</p>
+					<div class="row">
+						<div class="col-md-8 mb5">
+							<select
+								name="siteID"
+								id="siteID"
+								class="form-control input-sm"
+							>
+	
+								<cfloop array="#prc.allSites#" index="thisSite">
+									<cfif thisSite[ 'siteID' ] eq prc.oCurrentSite.getsiteID()><cfset siteOK = true></cfif>
+									<option
+										value="#thisSite[ 'siteID' ]#"
+										<cfif thisSite[ 'siteID' ] eq prc.oCurrentSite.getsiteID()>selected="selected"</cfif>
+									>
+										#thisSite[ 'name' ]#
+									</option>
+								</cfloop>
+							</select>
+						</div>
+						<div class="col-md-4">
+							<cfif arrayLen( prc.allSites ) GT 0>
+								<button
+									type="button"
+									class="btn btn-primary btn-block p11"
+									onclick="addSite();return false;"
+								>
+									Add Site
+								</button>
+							<cfelse>
+								<button
+									type="button"
+									class="btn btn-primary btn-block p11"
+									onclick="alert( 'No Sites Found, Cannot Add!' ); return false"
+									disabled
+								>
+									Add Site
+								</button>
+							</cfif>
+						</div>
+					</div>
+				</cfif>
+			#html.endFieldSet()#
+			#html.endForm()#
+
+			<!--- Show/Remove Site Form --->
+			#html.startForm( name="assignedSites", class="form-vertical" )#
+				<cfif !arrayLen(prc.author.getSites())>
+					<div class="alert alert-info">No sites assigned!</div>
+				<cfelse>
+					<p>Below are the currently assigned sites. You can remove sites by clicking on the remove button (<i class="fa fa-dot-circle fa-lg text-red"></i>).</p>
+				</cfif>
+
+				<cfloop array="#prc.author.getSites()#" index="site">
+					<div>
+						<!--- Assigned --->
+						<cfif prc.oCurrentAuthor.hasPermission( "AUTHOR_ADMIN" )>
+							<!--- Remove --->
+							<a href="javascript:removeSite('#site.getID()#')" onclick="return confirm('Are you sure?')" title="Remove Site"><i class="fa fa-dot-circle fa-lg text-red"></i></a>
+						</cfif>
+						<!--- Name --->
+						<strong>#site.getName()#</strong>
+					</div>
+				</cfloop>
+			#html.endForm()#
+		</cfif>
+	</cfif>
 </cfoutput>

--- a/modules/contentbox/modules/contentbox-admin/views/authors/permissionsHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/authors/permissionsHelper.cfm
@@ -4,6 +4,7 @@
 ( () => {
 	$permissionForm = $( "##permissionForm" );
 	$groupsForm 	= $( "##groupsForm" );
+	$siteForm       = $( "##siteForm" )
 } )();
 <cfif prc.oCurrentAuthor.hasPermission( "AUTHOR_ADMIN" )>
 function addPermissions(){
@@ -70,6 +71,40 @@ function removePermissionGroup( permissionGroupID ){
 		function(){
 			$( "##groupsLoader" ).slideUp();
 			// load permissions via container
+			loadPermissions();
+		}
+	);
+}
+function addSite(){
+	// loader
+	$( "##siteLoader" ).slideDown();
+	// Assign it
+	$.post(
+		'#event.buildLink( prc.xehSiteSave )#',
+		{
+			authorID : '#rc.authorID#',
+			siteID	 : $siteForm.find( "##siteID" ).val()
+		},
+		function(){
+			$( "##siteLoader" ).slideUp();
+			// load permissions via container
+			loadPermissions();
+		}
+	);
+}
+function removeSite( siteID ){
+	// loader
+	$( "##siteLoader" ).slideDown();
+	// Assign it
+	$.post(
+		'#event.buildLink( prc.xehSiteRemove )#',
+		{
+			authorID : '#rc.authorID#',
+			siteID	 : siteID
+		},
+		function(){
+			$( "##siteLoader" ).slideUp();
+			/// load permissions via container
 			loadPermissions();
 		}
 	);

--- a/modules/contentbox/modules/contentbox-admin/views/settings/sections/securityOptions.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/settings/sections/securityOptions.cfm
@@ -160,7 +160,41 @@
 </fieldset>
 
 <fieldset>
-	<legend><i class="fa fa-filter"></i> <strong>Rate Limiter</strong></legend>
+	<legend><i class="fa fa-lock fa-lg"></i> Sites by User</legend>
+
+	<!--- Author Site Permissions --->
+	<div class="form-group">
+        #html.label( class="control-label", field="cb_security_limit_sites_by_author", content="Limit sites by user:" )#
+        <div class="controls">
+            <small>When enabled, users will be limited to sites they can edit or administrate by default.</small><br/><br />
+            #html.checkbox(
+				name    = "cb_limit_sites_by_author_toggle",
+				data	= { toggle: 'toggle', match: 'cb_limit_sites_by_author' },
+				checked	= prc.cbSettings.cb_security_limit_sites_by_author
+			)#
+			#html.hiddenField(
+				name	= "cb_limit_sites_by_author",
+				value	= prc.cbSettings.cb_security_limit_sites_by_author
+			)#
+        </div>
+    </div>
+    <!--- All Sites Permission --->
+    <div class="form-group">
+        #html.label(class="control-label",field="cb_security_all_sites_permission",content="All Sites Permission: " )#
+        <div class="controls">
+            <small>The permission that will allow a user to administer or edit all sites.</small><br/>
+            #html.textField(
+                name="cb_security_all_sites_permission",
+                size="60",
+                class="form-control",
+                value=prc.cbSettings.cb_security_all_sites_permission
+            )#
+        </div>
+    </div>
+</fieldset>
+
+<fieldset>
+	<legend><i class="fa fa-filter"></i> Rate Limiter</legend>
 	<!--- Rate Limiter --->
 	<div class="form-group">
         #html.label( class="control-label", field="cb_security_rate_limiter", content="Enable Rate Limiter:" )#


### PR DESCRIPTION
Description

Added this new feature to support limiting access to sites :

    When creating a user, you can designate the sites they are assigned to, or choose the _ALL_SITES permission

    When editing a user, you can designate which sites they have access to in the permissions tab or choose the _ALL_SITES permission (Must have admin permissions)

    As a user, you can only see the sites you have access to

   The site switcher filters by the sites you have access to unless you have the '_ALL_SITES' permission

    In the database the Author has a many to many relationship to Site.

    In case this new feature is not required, there is a new setting that can turn it off and on and another to rename the permission used for '_ALL_SITES'

Also fixed a couple of spelling mistakes neat the changes I made in comments and text.

**Motivation**    
I built this so that our community centre can give various customers who run classes and activities at the centre can manage their own pages 

**Tests**
There are no tests yet

It is very close to the request in CONTENTBOX-1207 but has the settings in the permission tab rather than a separate tab.

- [ X ] Improvement
- [ X ] New Feature
- [ X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ X ] This change requires a documentation update

## Checklist

- [ X ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Unfortunately, I have no way to run the existing unit tests at present
