### PR TITLE
Fix ContentBox init migrations for PostgreSQL

### DIFF
--- a/modules/contentbox/migrations/2022_11_23_142439_v_6_0_0_Convert-Featured-cbfs.cfc
+++ b/modules/contentbox/migrations/2022_11_23_142439_v_6_0_0_Convert-Featured-cbfs.cfc
@@ -12,7 +12,7 @@ component {
 			.newQuery()
 			.from( "cb_setting" )
 			.where( "name", "cb_media_directoryRoot" )
-			.where( "isCore", 1 )
+			.where( "isCore", qb.getGrammar().convertToBooleanType( true ) )
 			.first();
 
 		if ( !structKeyExists( mediaRoot, "value" ) ) {

--- a/modules/contentbox/migrations/init/seed_permissions.cfc
+++ b/modules/contentbox/migrations/init/seed_permissions.cfc
@@ -184,9 +184,10 @@ component {
 			}
 		];
 
+		var falseBinding = query.getGrammar().convertToBooleanType( false );
 		perms = perms.map( ( thisPerm ) => {
 			thisPerm[ "permissionID" ] = createUUID();
-			thisPerm[ "isDeleted" ]    = 0;
+			thisPerm[ "isDeleted" ]    = falseBinding;
 			thisPerm[ "createdDate" ]  = thisPerm[ "modifiedDate" ] = now();
 			return thisPerm;
 		} );

--- a/modules/contentbox/migrations/init/seed_roles.cfc
+++ b/modules/contentbox/migrations/init/seed_roles.cfc
@@ -1,9 +1,10 @@
 component {
 
 	function seed( schema, query ){
+		var falseBinding = query.getGrammar().convertToBooleanType( false );
 		var admin = {
 			"roleID"       : createUUID(),
-			"isDeleted"    : 0,
+			"isDeleted"    : falseBinding,
 			"createdDate"  : now(),
 			"modifiedDate" : now(),
 			"role"         : "Administrator",
@@ -11,7 +12,7 @@ component {
 		};
 		var editor = {
 			"roleID"       : createUUID(),
-			"isDeleted"    : 0,
+			"isDeleted"    : falseBinding,
 			"createdDate"  : now(),
 			"modifiedDate" : now(),
 			"role"         : "Editor",

--- a/modules/contentbox/migrations/util/MigrationUtils.cfm
+++ b/modules/contentbox/migrations/util/MigrationUtils.cfm
@@ -20,22 +20,16 @@ function getUUID(){
  * @targetcolumn The column to check
  */
 boolean function hasColumn( targetTable, targetColumn ){
-	// Check for column created
-	cfdbinfo(
-		name  = "local.qSettingColumns",
-		type  = "columns",
-		table = arguments.targetTable
+	// Use information_schema directly so the check is dialect-safe and preserves
+	// identifier case (cfdbinfo lowercases table names which breaks on PostgreSQL).
+	var result = queryExecute(
+		"SELECT 1 FROM information_schema.columns WHERE table_name = :tableName AND column_name = :columnName",
+		{
+			tableName  : arguments.targetTable,
+			columnName : arguments.targetColumn
+		}
 	);
-
-	if (
-		qSettingColumns.filter( ( thisRow ) => {
-			// systemOutput( thisRow, true );
-			return thisRow.column_name == targetColumn
-		} ).recordCount > 0
-	) {
-		return true;
-	}
-	return false;
+	return result.recordCount > 0;
 }
 
 /**


### PR DESCRIPTION
# Description

ContentBox's initial migrations assume MySQL's lax boolean handling and cfdbinfo's behavior against lowercase-only identifiers. Both break on PostgreSQL. This PR makes the migrations dialect-safe without affecting MySQL.      

## Changes                                                                                                                                                                                                                           
                                                            
  - migrations/init/seed_permissions.cfc, migrations/init/seed_roles.cfc — isDeleted was seeded with the integer 0. PostgreSQL rejects this against a boolean column (column "isDeleted" is of type boolean but expression is of    
  type integer). CFML's isNumeric(false) returns true, so qb infers INTEGER before it checks boolean and binds false as integer anyway. Switched to query.getGrammar().convertToBooleanType( false ), qb's native helper that
  returns a correctly typed binding struct per dialect ({value: false, cfsqltype: "OTHER"} on Postgres, {value: 0, cfsqltype: "TINYINT"} on MySQL).                                                                                 
  - migrations/util/MigrationUtils.cfm — the hasColumn() helper used cfdbinfo type="columns", which lowercases the table name before hitting Postgres metadata and so can't find case-preserved tables like cb_securityRule.
  Replaced with a direct information_schema.columns query, which preserves the table name verbatim and works on both MySQL and PostgreSQL. No call-site changes needed.                                                             
  - migrations/2022_11_23_142439_v_6_0_0_Convert-Featured-cbfs.cfc — .where( "isCore", 1 ) triggers operator does not exist: boolean = integer on Postgres. Same fix as the seeds: .where( "isCore", 
  qb.getGrammar().convertToBooleanType( true ) ).                                                          

## Jira Issues
https://ortussolutions.atlassian.net/browse/CONTENTBOX-1560

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
