### PR TITLE
Fix JavaScript syntax errors in content editor

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/views/content/editorHelper.cfm
+++ b/modules/contentbox/modules/contentbox-admin/views/content/editorHelper.cfm
@@ -1,84 +1,82 @@
 <cfoutput>
-	<script>
-window.authentication = #toJSON( prc.jwtTokens )#window.assignedTemplate = #(
-	!isNull( prc.oContent.getContentTemplate() )
-		? toJSON( prc
-				.oContent
-				.getContentTemplate()
-				.getMemento() )
-		: booleanFormat( false )
-)#// Editor alerts model
-function alertsModel(){
-	return {
-		alerts : [],
+    <script>
+        window.authentication = #toJSON(prc.jwtTokens)#;
+        window.assignedTemplate = #(
+			!isNull( prc.oContent.getContentTemplate() )
+				? toJSON(prc.oContent.getContentTemplate().getMemento())
+				: booleanFormat(false)
+		)#;
 
-		init(){
-			$nextTick( () => window.alerts = this.alerts )
-		},
+        // Editor alerts model
+        function alertsModel(){
+            return {
+                alerts : [],
+                init(){
+                    $nextTick( () => window.alerts = this.alerts )
+                },
+                removeAlert : index => this.alerts.splice( index, 1 ),
+                addAlert( alert ){
+                    if( alert instanceof CustomEvent ){
+                        alert = alert.detail
+                    }
+                    this.alerts.push( alert );
+                }
+            }
+        }
 
-		removeAlert : index => this.alerts.splice( index, 1 ),
+        /**
+        * Enclosure for custom editor startup
+        */
+        $cbEditorStartup = function(){#prc.oEditorDriver.startup()#}
 
-		addAlert( alert ){
-			if( alert instanceof CustomEvent ){
-				alert = alert.detail
-			}
-			this.alerts.push( alert );
-		}
-	}
-}
+        /**
+        * Enclosure for custom editor startup
+        */
+        $cbEditorShutdown = function(){#prc.oEditorDriver.shutdown()#}
 
-/**
- * Enclosure for custom editor startup
- */
-$cbEditorStartup = function(){#prc.oEditorDriver.startup()#}
+        // Load Editor Provider Assets now
+        #prc.oEditorDriver.loadAssets()#
 
-/**
- * Enclosure for custom editor startup
- */
-$cbEditorShutdown = function(){#prc.oEditorDriver.shutdown()#}
+        // On Dom Ready
+        document.addEventListener( "DOMContentLoaded", () => {
 
-// Load Editor Provider Assets now#prc.oEditorDriver.loadAssets()#// On Dom Ready
-document.addEventListener( "DOMContentLoaded", () => {
+            // Dynamic global variables coming from ColdFusion
+            $cbEditorConfig = {
+                adminEntryPoint    : "#prc.cbAdminEntryPoint#",
+                adminEntryURL      : "#event.buildLink(prc.cbAdminEntryPoint)#",
+                changelogMandatory : #prc.cbSettings.cb_versions_commit_mandatory#,
+                isBlogDisabled     : #prc.oCurrentSite.getIsBlogEnabled() ? 'false' : 'true'#,
+                // Set by the content type handler
+                slugifyURL         : "#event.buildLink(prc.xehSlugify)#",
+                slugCheckURL       : "#event.buildLink(prc.xehSlugCheck)#"
+            };
 
-	// Dynamic global variables coming from ColdFusion
-	$cbEditorConfig = {
-		adminEntryPoint 	: "#prc.cbAdminEntryPoint#",
-adminEntryURL		: "#event.buildLink( prc.cbAdminEntryPoint )#",
-changelogMandatory	: #prc.cbSettings.cb_versions_commit_mandatory#,
-isBlogDisabled		: #prc.oCurrentSite.getIsBlogEnabled() ? "false" : "true"#,
-// Set by the content type handler
-slugifyURL			: "#event.buildLink( prc.xehSlugify )#",
-slugCheckURL		: "#event.buildLink( prc.xehSlugCheck )#"
-};
+            // Editor Form Pointer
+            $contentForm = $( "##contentForm" );
 
-	// Editor Form Pointer
-$contentForm = $( "##contentForm" );
-
-// Setup the Editors
-setupEditors(
-	$contentForm,
-	<cfif structKeyExists( prc.oContent, "getExcerpt" )>
-		true,
-	<cfelse>
-		false,
-	</cfif>
-	
-	
-	
-	
-	
-		'#event.buildLink( prc.xehContentSave )#'
-	);
-
-	// Apply content templates
-	if( document.getElementById( 'contentTemplate' ) && document.getElementById( 'contentTemplate' ).value !== 'null' ){
-		applyContentTemplate( document.getElementById( 'contentTemplate' ).value );
-	}
-} );
-</script>
+            // Setup the Editors
+            setupEditors(
+                $contentForm,
+                <cfif structKeyExists(prc.oContent, 'getExcerpt')>
+        			true,
+                <cfelse>
+                    false,
+    			</cfif>
+    
 
 
 
 
 
+
+
+                '#event.buildLink(prc.xehContentSave)#'
+            );
+
+            // Apply content templates
+            if( document.getElementById( 'contentTemplate' ) && document.getElementById( 'contentTemplate' ).value !== 'null' ){
+                applyContentTemplate( document.getElementById( 'contentTemplate' ).value );
+            }
+        } );
+    </script>
 </cfoutput>


### PR DESCRIPTION
# Description

## Fix: JavaScript syntax errors in content editor (v6.4.0-snapshot)

1. **`Uncaught SyntaxError: Unexpected identifier 'window'** — Missing semicolons after ColdFusion-generated assignments in `editorHelper.cfm` caused adjacent JS statements to be parsed as a single invalid expression.

2. **`Illegal return statement`** — In `editorHelper.cfm`, the `loadAssets()` call was placed immediately after a single-line JS comment (`//`) with no line break. The browser treated the first line of the injected JS (`function getContentEditor(){`) as part of the comment, leaving the inner `return` statement outside any function scope.

3. **`Alpine Expression Error: alertsModel is not defined`** — This was a cascading failure caused by errors #1 and #2 aborting script execution before `alertsModel()` could be declared in the global scope.

### Changes
- Added explicit semicolons after ColdFusion-interpolated JS assignments (`window.authentication`, `window.assignedTemplate`).
- Added a line break between the `// Load Editor Provider Assets now` comment and the `#prc.oEditorDriver.loadAssets()#` call to prevent the function declaration from being swallowed by the comment.

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
