### PR TITLE
Fix the buildPageFeed method in the RSS Service

### DIFF
--- a/modules/contentbox/models/rss/RSSService.cfc
+++ b/modules/contentbox/models/rss/RSSService.cfc
@@ -236,10 +236,11 @@ component singleton {
 
 		// Attach permalinks
 		for ( var i = 1; i LTE entryResults.count; i++ ) {
+			var entrySlug = entryResults.content[ i ].getSlug();
 			// build URL to entry
-			qEntries.link[ i ] = variables.CBHelper.linkEntry( qEntries.slug[ i ] );
+			qEntries.link[ i ] = variables.CBHelper.linkEntry( entrySlug );
 			qEntries.guid_permalink[ i ] = false;
-			qEntries.guid_string[ i ] = variables.CBHelper.linkEntry( qEntries.slug[ i ] );
+			qEntries.guid_string[ i ] = variables.CBHelper.linkEntry( entrySlug );
 
 			qEntries.author[ i ] = "#entryResults.content[ i ].getAuthorEmail()# (#entryResults.content[ i ].getAuthorName()#)";
 			qEntries.linkComments[ i ] = variables.CBHelper.linkComments( entryResults.content[ i ] );
@@ -338,13 +339,14 @@ component singleton {
 
 		// Attach permalinks
 		for ( var i = 1; i LTE pageResults.count; i++ ) {
+			var pageSlug = pageResults.content[ i ].getSlug();
 			// build URL to entry
-			qPages.link[ i ] = variables.CBHelper.linkPage( qPages.slug );
+			qPages.link[ i ] = variables.CBHelper.linkPage( pageSlug );
 			qPages.author[ i ] = "#pageResults.content[ i ].getAuthorEmail()# (#pageResults.content[ i ].getAuthorName()#)";
 			qPages.linkComments[ i ] = variables.CBHelper.linkComments( pageResults.content[ i ] );
 			qPages.categories[ i ] = pageResults.content[ i ].getCategoriesList();
 			qPages.guid_permalink[ i ] = false;
-			qPages.guid_string[ i ] = variables.CBHelper.linkPage( qPages.slug );
+			qPages.guid_string[ i ] = variables.CBHelper.linkPage( pageSlug );
 			if ( pageResults.content[ i ].hasExcerpt() ) {
 				qPages.content[ i ] = pageResults.content[ i ].renderExcerpt();
 			} else {

--- a/modules/contentbox/models/rss/RSSService.cfc
+++ b/modules/contentbox/models/rss/RSSService.cfc
@@ -6,571 +6,464 @@
  * RSS Services for this application
  */
 component singleton {
-	// DI
-	property name="entryService" inject="entryService@contentbox";
 
-	property name="pageService" inject="pageService@contentbox";
+    // DI
+    property name="entryService" inject="entryService@contentbox";
 
-	property name="contentService" inject="contentService@contentbox";
+    property name="pageService" inject="pageService@contentbox";
 
-	property name="commentService" inject="commentService@contentbox";
+    property name="contentService" inject="contentService@contentbox";
 
-	property name="CBHelper" inject="CBHelper@contentbox";
+    property name="commentService" inject="commentService@contentbox";
 
-	property name="feedGenerator" inject="feedGenerator@cbfeeds";
+    property name="CBHelper" inject="CBHelper@contentbox";
 
-	property name="log" inject="logbox:logger:{this}";
+    property name="feedGenerator" inject="feedGenerator@cbfeeds";
 
-	/**
-	 * Constructor
-	 *
-	 * @settingService.inject id:settingService@contentbox
-	 * @cacheBox.inject       cachebox
-	 */
-	RSSService function init( required settingService, required cacheBox ) {
-		// Dependencies
-		variables.settingService = arguments.settingService;
-		variables.cacheBox = arguments.cacheBox;
-		// Get all settings
-		var settings = settingService.getAllSettings();
-		// setup the user selected cache provider
-		variables.cache = cacheBox.getCache( settings.cb_rss_cacheName );
+    property name="log" inject="logbox:logger:{this}";
 
-		return this;
-	}
+    /**
+     * Constructor
+     *
+     * @settingService.inject id:settingService@contentbox
+     * @cacheBox.inject       cachebox
+     */
+    RSSService function init(required settingService, required cacheBox) {
+        // Dependencies
+        variables.settingService = arguments.settingService;
+        variables.cacheBox = arguments.cacheBox;
+        // Get all settings
+        var settings = settingService.getAllSettings();
+        // setup the user selected cache provider
+        variables.cache = cacheBox.getCache(settings.cb_rss_cacheName);
 
-	/************************************** PUBLIC *********************************************/
+        return this;
+    }
 
-	/**
-	 * Clean RSS caches asynchronously
-	 *
-	 * @comments Clear comment caches or not, defaults to false
-	 * @slug     The content slug to clear on
-	 */
-	RSSService function clearCaches( boolean comments = false, string slug = "" ) {
-		var cacheKey = "";
+    /************************************** PUBLIC *********************************************/
 
-		// compose cache key
-		if ( arguments.comments ) {
-			cacheKey = "cb-feeds-#cgi.HTTP_HOST#-content-comments-";
-		} else {
-			cacheKey = "cb-feeds-#cgi.HTTP_HOST#-content";
-		}
+    /**
+     * Clean RSS caches asynchronously
+     *
+     * @comments Clear comment caches or not, defaults to false
+     * @slug     The content slug to clear on
+     */
+    RSSService function clearCaches(boolean comments = false, string slug = '') {
+        var cacheKey = '';
 
-		// clear by snippet
-		variables.cache.clearByKeySnippet( keySnippet = cacheKey, async = false );
+        // compose cache key
+        if (arguments.comments) {
+            cacheKey = 'cb-feeds-#cgi.HTTP_HOST#-content-comments-';
+        } else {
+            cacheKey = 'cb-feeds-#cgi.HTTP_HOST#-content';
+        }
 
-		// log
-		if ( variables.log.canInfo() ) {
-			variables.log.info(
-					"Sent clear command using the following content key: #cacheKey# from provider: #variables.cache.getName()#"
-				);
-		}
+        // clear by snippet
+        variables.cache.clearByKeySnippet(keySnippet = cacheKey, async = false);
 
-		return this;
-	}
+        // log
+        if (variables.log.canInfo()) {
+            variables.log.info(
+                'Sent clear command using the following content key: #cacheKey# from provider: #variables.cache.getName()#'
+            );
+        }
 
-	/**
-	 * Clean All RSS caches NOW BABY, NOW!
-	 */
-	RSSService function clearAllCaches( boolean async = false ) {
-		variables.cache.clearByKeySnippet( keySnippet = "cb-feeds", async = arguments.async );
-		return this;
-	}
+        return this;
+    }
 
-	/**
-	 * Build RSS feeds for contentbox content objects
-	 *
-	 * @slug        The page or entry slug to filter on.
-	 * @comments    Retrieve the comments RSS feed or content feed, defaults to false
-	 * @category    Filter the content feed with categories
-	 * @contentType The contentType to build an RSS feed on. Empty is for the site. Available content types are [page,entry]
-	 * @siteID      The site Id to filter on
-	 */
-	function getRSS(
-		string slug      = "",
-		boolean comments = false,
-		category         = "",
-		contentType      = "",
-		string siteID    = ""
-	) {
-		var settings = settingService.getAllSettings();
-		var rssFeed = "";
-		var cacheKey = "";
+    /**
+     * Clean All RSS caches NOW BABY, NOW!
+     */
+    RSSService function clearAllCaches(boolean async = false) {
+        variables.cache.clearByKeySnippet(keySnippet = 'cb-feeds', async = arguments.async);
+        return this;
+    }
 
-		// Comments cache Key
-		if ( arguments.comments ) {
-			cacheKey = "cb-feeds-#cgi.HTTP_HOST#-content-comments-#arguments.slug#";
-		} else {
-			// Entries cache Key
-			cacheKey = "cb-feeds-#cgi.HTTP_HOST#-content-#hash( arguments.category & arguments.contentType )#";
-		}
+    /**
+     * Build RSS feeds for contentbox content objects
+     *
+     * @slug        The page or entry slug to filter on.
+     * @comments    Retrieve the comments RSS feed or content feed, defaults to false
+     * @category    Filter the content feed with categories
+     * @contentType The contentType to build an RSS feed on. Empty is for the site. Available content types are [page,entry]
+     * @siteID      The site Id to filter on
+     */
+    function getRSS(
+        string slug = '',
+        boolean comments = false,
+        category = '',
+        contentType = '',
+        string siteID = ''
+    ) {
+        var settings = settingService.getAllSettings();
+        var rssFeed = '';
+        var cacheKey = '';
 
-		// Retrieve via caching? and caching active
-		if ( settings.cb_rss_caching ) {
-			var rssFeed = variables.cache.get( cacheKey );
-			if ( !isNull( rssFeed ) ) {
-				return rssFeed;
-			}
-		}
+        // Comments cache Key
+        if (arguments.comments) {
+            cacheKey = 'cb-feeds-#cgi.HTTP_HOST#-content-comments-#arguments.slug#';
+        } else {
+            // Entries cache Key
+            cacheKey = 'cb-feeds-#cgi.HTTP_HOST#-content-#hash(arguments.category & arguments.contentType)#';
+        }
 
-		// Content Type
-		switch ( arguments.contentType ) {
-			// Pages
-			case "page": {
-				// Building comment feed or content feed
-				if ( arguments.comments ) {
-					arguments.contentType = "Page";
-					rssfeed = buildCommentFeed( argumentCollection = arguments );
-				} else {
-					rssfeed = buildPageFeed( argumentCollection = arguments );
-				}
-				break;
-			}
-			// Blog
-			case "entry": {
-				// Building comment feed or content feed
-				if ( arguments.comments ) {
-					arguments.contentType = "Entry";
-					rssfeed = buildCommentFeed( argumentCollection = arguments );
-				} else {
-					rssfeed = buildEntryFeed( argumentCollection = arguments );
-				}
-				break;
-			}
-			// Default Site
-			default: {
-				// Building comment feed or content feed
-				if ( arguments.comments ) {
-					rssfeed = buildCommentFeed( argumentCollection = arguments );
-				} else {
-					rssfeed = buildContentFeed( argumentCollection = arguments );
-				}
-				break;
-			}
-		}
-		// end content type switch
+        // Retrieve via caching? and caching active
+        if (settings.cb_rss_caching) {
+            var rssFeed = variables.cache.get(cacheKey);
+            if (!isNull(rssFeed)) {
+                return rssFeed;
+            }
+        }
 
-		// Cache it with settings
-		if ( settings.cb_rss_caching ) {
-			variables.cache.set(
-					cacheKey,
-					rssFeed,
-					settings.cb_rss_cachingTimeout,
-					settings.cb_rss_cachingTimeoutIdle
-				);
-		}
+        // Content Type
+        switch (arguments.contentType) {
+            // Pages
+            case 'page': {
+                // Building comment feed or content feed
+                if (arguments.comments) {
+                    arguments.contentType = 'Page';
+                    rssfeed = buildCommentFeed(argumentCollection = arguments);
+                } else {
+                    rssfeed = buildPageFeed(argumentCollection = arguments);
+                }
+                break;
+            }
+            // Blog
+            case 'entry': {
+                // Building comment feed or content feed
+                if (arguments.comments) {
+                    arguments.contentType = 'Entry';
+                    rssfeed = buildCommentFeed(argumentCollection = arguments);
+                } else {
+                    rssfeed = buildEntryFeed(argumentCollection = arguments);
+                }
+                break;
+            }
+            // Default Site
+            default: {
+                // Building comment feed or content feed
+                if (arguments.comments) {
+                    rssfeed = buildCommentFeed(argumentCollection = arguments);
+                } else {
+                    rssfeed = buildContentFeed(argumentCollection = arguments);
+                }
+                break;
+            }
+        }
+        // end content type switch
 
-		return rssFeed;
-	}
+        // Cache it with settings
+        if (settings.cb_rss_caching) {
+            variables.cache.set(
+                cacheKey,
+                rssFeed,
+                settings.cb_rss_cachingTimeout,
+                settings.cb_rss_cachingTimeoutIdle
+            );
+        }
 
-	/************************************** PRIVATE *********************************************/
+        return rssFeed;
+    }
 
-	/**
-	 * Build entries feeds
-	 *
-	 * @category The category to filter on
-	 * @siteID   The site to filter on
-	 */
-	private function buildEntryFeed( string category = "", string siteID = "" ) {
-		var settings = settingService.getAllSettings();
-		var entryResults = entryService.findPublishedContent(
-				category = arguments.category,
-				max      = settings.cb_rss_maxEntries,
-				siteID   = arguments.siteID
-			);
-		var myArray = [];
-		var feedStruct = {};
-		var columnMap = {};
-		var qEntries = entityToQuery( entryResults.content );
+    /************************************** PRIVATE *********************************************/
 
-		// max checks
-		if ( settings.cb_rss_maxEntries LT entryResults.count ) {
-			entryResults.count = settings.cb_rss_maxEntries;
-		}
+    /**
+     * Build entries feeds
+     *
+     * @category The category to filter on
+     * @siteID   The site to filter on
+     */
+    private function buildEntryFeed(string category = '', string siteID = '') {
+        var settings = settingService.getAllSettings();
+        var entryResults = entryService.findPublishedContent(
+            category = arguments.category,
+            max = settings.cb_rss_maxEntries,
+            siteID = arguments.siteID
+        );
+        var myArray = [];
+        var feedStruct = {};
+        var columnMap = {};
+        var qEntries = entityToQuery(entryResults.content);
 
-		// Create the column maps
-		columnMap.title = "title";
-		columnMap.description = "content";
-		columnMap.pubDate = "publishedDate";
-		columnMap.link = "link";
-		columnMap.author = "author";
-		columnMap.category_tag = "categories";
+        // max checks
+        if (settings.cb_rss_maxEntries LT entryResults.count) {
+            entryResults.count = settings.cb_rss_maxEntries;
+        }
 
-		// Add necessary columns to query
-		queryAddColumn(
-			qEntries,
-			"link",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"linkComments",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"author",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"categories",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"content",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"guid_permalink",
-			myArray
-		);
-		queryAddColumn(
-			qEntries,
-			"guid_string",
-			myArray
-		);
+        // Create the column maps
+        columnMap.title = 'title';
+        columnMap.description = 'content';
+        columnMap.pubDate = 'publishedDate';
+        columnMap.link = 'link';
+        columnMap.author = 'author';
+        columnMap.category_tag = 'categories';
 
-		// Attach permalinks
-		for ( var i = 1; i LTE entryResults.count; i++ ) {
-			var entrySlug = entryResults.content[ i ].getSlug();
-			// build URL to entry
-			qEntries.link[ i ] = variables.CBHelper.linkEntry( entrySlug );
-			qEntries.guid_permalink[ i ] = false;
-			qEntries.guid_string[ i ] = variables.CBHelper.linkEntry( entrySlug );
+        // Add necessary columns to query
+        queryAddColumn(qEntries, 'link', myArray);
+        queryAddColumn(qEntries, 'linkComments', myArray);
+        queryAddColumn(qEntries, 'author', myArray);
+        queryAddColumn(qEntries, 'categories', myArray);
+        queryAddColumn(qEntries, 'content', myArray);
+        queryAddColumn(qEntries, 'guid_permalink', myArray);
+        queryAddColumn(qEntries, 'guid_string', myArray);
 
-			qEntries.author[ i ] = "#entryResults.content[ i ].getAuthorEmail()# (#entryResults.content[ i ].getAuthorName()#)";
-			qEntries.linkComments[ i ] = variables.CBHelper.linkComments( entryResults.content[ i ] );
-			qEntries.categories[ i ] = entryResults.content[ i ].getCategoriesList();
-			if ( entryResults.content[ i ].hasExcerpt() ) {
-				qEntries.content[ i ] = entryResults.content[ i ].renderExcerpt();
-			} else {
-				qEntries.content[ i ] = entryResults.content[ i ].renderContent();
-			}
-			qEntries.content[ i ] = cleanupContent( qEntries.content[ i ] );
-		}
+        // Attach permalinks
+        for (var i = 1; i LTE entryResults.count; i++) {
+            var entrySlug = entryResults.content[i].getSlug();
+            // build URL to entry
+            qEntries.link[i] = variables.CBHelper.linkEntry(entrySlug);
+            qEntries.guid_permalink[i] = false;
+            qEntries.guid_string[i] = variables.CBHelper.linkEntry(entrySlug);
 
-		// Generate feed items
-		feedStruct.title = "Blog " & settings.cb_rss_title;
-		feedStruct.generator = settings.cb_rss_generator;
-		feedStruct.copyright = settings.cb_rss_copyright;
-		feedStruct.description = settings.cb_rss_description;
-		if ( len( settings.cb_rss_webmaster ) ) {
-			feedStruct.webmaster = settings.cb_rss_webmaster;
-		}
-		feedStruct.pubDate = now();
-		feedStruct.lastbuilddate = now();
-		feedStruct.link = variables.CBHelper.linkHome();
-		feedStruct.items = qEntries;
+            qEntries.author[i] = '#entryResults.content[i].getAuthorEmail()# (#entryResults.content[i].getAuthorName()#)';
+            qEntries.linkComments[i] = variables.CBHelper.linkComments(entryResults.content[i]);
+            qEntries.categories[i] = entryResults.content[i].getCategoriesList();
+            if (entryResults.content[i].hasExcerpt()) {
+                qEntries.content[i] = entryResults.content[i].renderExcerpt();
+            } else {
+                qEntries.content[i] = entryResults.content[i].renderContent();
+            }
+            qEntries.content[i] = cleanupContent(qEntries.content[i]);
+        }
 
-		return variables.feedGenerator.createFeed( feedStruct, columnMap );
-	}
+        // Generate feed items
+        feedStruct.title = 'Blog ' & settings.cb_rss_title;
+        feedStruct.generator = settings.cb_rss_generator;
+        feedStruct.copyright = settings.cb_rss_copyright;
+        feedStruct.description = settings.cb_rss_description;
+        if (len(settings.cb_rss_webmaster)) {
+            feedStruct.webmaster = settings.cb_rss_webmaster;
+        }
+        feedStruct.pubDate = now();
+        feedStruct.lastbuilddate = now();
+        feedStruct.link = variables.CBHelper.linkHome();
+        feedStruct.items = qEntries;
 
-	/**
-	 * Build pages feeds
-	 *
-	 * @category The category to filter on
-	 * @siteID   The site to filter on
-	 */
-	private function buildPageFeed( string category = "", string siteID = "" ) {
-		var settings = settingService.getAllSettings();
-		var pageResults = variables.pageService.findPublishedContent(
-				category = arguments.category,
-				max      = settings.cb_rss_maxEntries,
-				siteID   = arguments.siteID
-			);
-		var myArray = [];
-		var feedStruct = {};
-		var columnMap = {};
-		var qPages = entityToQuery( pageResults.content );
+        return variables.feedGenerator.createFeed(feedStruct, columnMap);
+    }
 
-		// max checks
-		if ( settings.cb_rss_maxEntries LT pageResults.count ) {
-			pageResults.count = settings.cb_rss_maxEntries;
-		}
+    /**
+     * Build pages feeds
+     *
+     * @category The category to filter on
+     * @siteID   The site to filter on
+     */
+    private function buildPageFeed(string category = '', string siteID = '') {
+        var settings = settingService.getAllSettings();
+        var pageResults = variables.pageService.findPublishedContent(
+            category = arguments.category,
+            max = settings.cb_rss_maxEntries,
+            siteID = arguments.siteID
+        );
+        var myArray = [];
+        var feedStruct = {};
+        var columnMap = {};
+        var qPages = entityToQuery(pageResults.content);
 
-		// Create the column maps
-		columnMap.title = "title";
-		columnMap.description = "content";
-		columnMap.pubDate = "publishedDate";
-		columnMap.link = "link";
-		columnMap.author = "author";
-		columnMap.category_tag = "categories";
+        // max checks
+        if (settings.cb_rss_maxEntries LT pageResults.count) {
+            pageResults.count = settings.cb_rss_maxEntries;
+        }
 
-		// Add necessary columns to query
-		queryAddColumn(
-			qPages,
-			"link",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"linkComments",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"author",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"categories",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"content",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"guid_permalink",
-			myArray
-		);
-		queryAddColumn(
-			qPages,
-			"guid_string",
-			myArray
-		);
+        // Create the column maps
+        columnMap.title = 'title';
+        columnMap.description = 'content';
+        columnMap.pubDate = 'publishedDate';
+        columnMap.link = 'link';
+        columnMap.author = 'author';
+        columnMap.category_tag = 'categories';
 
-		// Attach permalinks
-		for ( var i = 1; i LTE pageResults.count; i++ ) {
-			var pageSlug = pageResults.content[ i ].getSlug();
-			// build URL to entry
-			qPages.link[ i ] = variables.CBHelper.linkPage( pageSlug );
-			qPages.author[ i ] = "#pageResults.content[ i ].getAuthorEmail()# (#pageResults.content[ i ].getAuthorName()#)";
-			qPages.linkComments[ i ] = variables.CBHelper.linkComments( pageResults.content[ i ] );
-			qPages.categories[ i ] = pageResults.content[ i ].getCategoriesList();
-			qPages.guid_permalink[ i ] = false;
-			qPages.guid_string[ i ] = variables.CBHelper.linkPage( pageSlug );
-			if ( pageResults.content[ i ].hasExcerpt() ) {
-				qPages.content[ i ] = pageResults.content[ i ].renderExcerpt();
-			} else {
-				qPages.content[ i ] = pageResults.content[ i ].renderContent();
-			}
-			qPages.content[ i ] = cleanupContent( qPages.content[ i ] );
-		}
+        // Add necessary columns to query
+        queryAddColumn(qPages, 'link', myArray);
+        queryAddColumn(qPages, 'linkComments', myArray);
+        queryAddColumn(qPages, 'author', myArray);
+        queryAddColumn(qPages, 'categories', myArray);
+        queryAddColumn(qPages, 'content', myArray);
+        queryAddColumn(qPages, 'guid_permalink', myArray);
+        queryAddColumn(qPages, 'guid_string', myArray);
 
-		// Generate feed items
-		feedStruct.title = "Page " & settings.cb_rss_title;
-		feedStruct.generator = settings.cb_rss_generator;
-		feedStruct.copyright = settings.cb_rss_copyright;
-		feedStruct.description = settings.cb_rss_description;
-		if ( len( settings.cb_rss_webmaster ) ) {
-			feedStruct.webmaster = settings.cb_rss_webmaster;
-		}
-		feedStruct.pubDate = now();
-		feedStruct.lastbuilddate = now();
-		feedStruct.link = CBHelper.linkHome();
-		feedStruct.items = qPages;
+        // Attach permalinks
+        for (var i = 1; i LTE pageResults.count; i++) {
+            var pageSlug = pageResults.content[i].getSlug();
+            // build URL to entry
+            qPages.link[i] = variables.CBHelper.linkPage(pageSlug);
+            qPages.author[i] = '#pageResults.content[i].getAuthorEmail()# (#pageResults.content[i].getAuthorName()#)';
+            qPages.linkComments[i] = variables.CBHelper.linkComments(pageResults.content[i]);
+            qPages.categories[i] = pageResults.content[i].getCategoriesList();
+            qPages.guid_permalink[i] = false;
+            qPages.guid_string[i] = variables.CBHelper.linkPage(pageSlug);
+            if (pageResults.content[i].hasExcerpt()) {
+                qPages.content[i] = pageResults.content[i].renderExcerpt();
+            } else {
+                qPages.content[i] = pageResults.content[i].renderContent();
+            }
+            qPages.content[i] = cleanupContent(qPages.content[i]);
+        }
 
-		return variables.feedGenerator.createFeed( feedStruct, columnMap );
-	}
+        // Generate feed items
+        feedStruct.title = 'Page ' & settings.cb_rss_title;
+        feedStruct.generator = settings.cb_rss_generator;
+        feedStruct.copyright = settings.cb_rss_copyright;
+        feedStruct.description = settings.cb_rss_description;
+        if (len(settings.cb_rss_webmaster)) {
+            feedStruct.webmaster = settings.cb_rss_webmaster;
+        }
+        feedStruct.pubDate = now();
+        feedStruct.lastbuilddate = now();
+        feedStruct.link = CBHelper.linkHome();
+        feedStruct.items = qPages;
 
-	/**
-	 * Build content feeds
-	 *
-	 * @category The category to filter on
-	 * @siteID   The site to filter on
-	 */
-	private function buildContentFeed( string category = "", string siteID = "" ) {
-		var settings = variables.settingService.getAllSettings();
-		var contentResults = variables.contentService.findPublishedContent(
-				category = arguments.category,
-				max      = settings.cb_rss_maxEntries,
-				siteID   = arguments.siteID
-			);
-		var myArray = [];
-		var feedStruct = {};
-		var columnMap = {};
-		var qContent = entityToQuery( contentResults.content );
+        return variables.feedGenerator.createFeed(feedStruct, columnMap);
+    }
 
-		// max checks
-		if ( settings.cb_rss_maxEntries LT contentResults.count ) {
-			contentResults.count = settings.cb_rss_maxEntries;
-		}
+    /**
+     * Build content feeds
+     *
+     * @category The category to filter on
+     * @siteID   The site to filter on
+     */
+    private function buildContentFeed(string category = '', string siteID = '') {
+        var settings = variables.settingService.getAllSettings();
+        var contentResults = variables.contentService.findPublishedContent(
+            category = arguments.category,
+            max = settings.cb_rss_maxEntries,
+            siteID = arguments.siteID
+        );
+        var myArray = [];
+        var feedStruct = {};
+        var columnMap = {};
+        var qContent = entityToQuery(contentResults.content);
 
-		// Create the column maps
-		columnMap.title = "title";
-		columnMap.description = "content";
-		columnMap.pubDate = "publishedDate";
-		columnMap.link = "link";
-		columnMap.author = "author";
-		columnMap.category_tag = "categories";
+        // max checks
+        if (settings.cb_rss_maxEntries LT contentResults.count) {
+            contentResults.count = settings.cb_rss_maxEntries;
+        }
 
-		// Add necessary columns to query
-		queryAddColumn(
-			qContent,
-			"link",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"linkComments",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"author",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"categories",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"content",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"guid_permalink",
-			myArray
-		);
-		queryAddColumn(
-			qContent,
-			"guid_string",
-			myArray
-		);
+        // Create the column maps
+        columnMap.title = 'title';
+        columnMap.description = 'content';
+        columnMap.pubDate = 'publishedDate';
+        columnMap.link = 'link';
+        columnMap.author = 'author';
+        columnMap.category_tag = 'categories';
 
-		// Attach permalinks
-		for ( var i = 1; i LTE contentResults.count; i++ ) {
-			// Check for empty authors, just in case.
-			var authorEmail = len( contentResults.content[ i ].getAuthorEmail() )
-				? contentResults.content[ i ].getAuthorEmail()
-				: "nobody@nobody.com";
-			var authorName = len( contentResults.content[ i ].getAuthorName() )
-				? contentResults.content[ i ].getAuthorName()
-				: "nobody";
+        // Add necessary columns to query
+        queryAddColumn(qContent, 'link', myArray);
+        queryAddColumn(qContent, 'linkComments', myArray);
+        queryAddColumn(qContent, 'author', myArray);
+        queryAddColumn(qContent, 'categories', myArray);
+        queryAddColumn(qContent, 'content', myArray);
+        queryAddColumn(qContent, 'guid_permalink', myArray);
+        queryAddColumn(qContent, 'guid_string', myArray);
 
-			// build URL to entry
-			qContent.link[ i ] = CBHelper.linkContent( contentResults.content[ i ] );
-			qContent.author[ i ] = "#authorEmail# (#authorName#)";
-			qContent.linkComments[ i ] = CBHelper.linkComments( contentResults.content[ i ] );
-			qContent.categories[ i ] = contentResults.content[ i ].getCategoriesList();
-			qContent.content[ i ] = cleanupContent( contentResults.content[ i ].renderContent() );
-			qContent.guid_permalink[ i ] = false;
-			qContent.guid_string[ i ] = CBHelper.linkContent( contentResults.content[ i ] );
-		}
+        // Attach permalinks
+        for (var i = 1; i LTE contentResults.count; i++) {
+            // Check for empty authors, just in case.
+            var authorEmail = len(contentResults.content[i].getAuthorEmail())
+             ? contentResults.content[i].getAuthorEmail()
+             : 'nobody@nobody.com';
+            var authorName = len(contentResults.content[i].getAuthorName())
+             ? contentResults.content[i].getAuthorName()
+             : 'nobody';
 
-		// Generate feed items
-		feedStruct.title = "Content " & settings.cb_rss_title;
-		feedStruct.generator = settings.cb_rss_generator;
-		feedStruct.copyright = settings.cb_rss_copyright;
-		feedStruct.description = settings.cb_rss_description;
-		if ( len( settings.cb_rss_webmaster ) ) {
-			feedStruct.webmaster = settings.cb_rss_webmaster;
-		}
-		feedStruct.pubDate = now();
-		feedStruct.lastbuilddate = now();
-		feedStruct.link = CBHelper.linkHome();
-		feedStruct.items = qContent;
+            // build URL to entry
+            qContent.link[i] = CBHelper.linkContent(contentResults.content[i]);
+            qContent.author[i] = '#authorEmail# (#authorName#)';
+            qContent.linkComments[i] = CBHelper.linkComments(contentResults.content[i]);
+            qContent.categories[i] = contentResults.content[i].getCategoriesList();
+            qContent.content[i] = cleanupContent(contentResults.content[i].renderContent());
+            qContent.guid_permalink[i] = false;
+            qContent.guid_string[i] = CBHelper.linkContent(contentResults.content[i]);
+        }
 
-		return variables.feedGenerator.createFeed( feedStruct, columnMap );
-	}
+        // Generate feed items
+        feedStruct.title = 'Content ' & settings.cb_rss_title;
+        feedStruct.generator = settings.cb_rss_generator;
+        feedStruct.copyright = settings.cb_rss_copyright;
+        feedStruct.description = settings.cb_rss_description;
+        if (len(settings.cb_rss_webmaster)) {
+            feedStruct.webmaster = settings.cb_rss_webmaster;
+        }
+        feedStruct.pubDate = now();
+        feedStruct.lastbuilddate = now();
+        feedStruct.link = CBHelper.linkHome();
+        feedStruct.items = qContent;
 
-	/**
-	 * Build comment feeds according to filtering elements
-	 *
-	 * @slug        The content slug to filter on
-	 * @contentType The content type discriminator to filter on
-	 * @siteID      The site to filter on
-	 */
-	private function buildCommentFeed(
-		string slug        = "",
-		string contentType = "",
-		string siteID      = ""
-	) {
-		var settings = variables.settingService.getAllSettings();
-		var commentResults = variables.commentService.findAllApproved(
-				contentID   = variables.contentService.getIDBySlug( arguments.slug ),
-				contentType = arguments.contentType,
-				max         = settings.cb_rss_maxComments,
-				siteID      = arguments.siteID
-			);
-		var myArray = [];
-		var feedStruct = {};
-		var columnMap = {};
-		var qComments = entityToQuery( commentResults.comments );
+        return variables.feedGenerator.createFeed(feedStruct, columnMap);
+    }
 
-		// Create the column maps
-		columnMap.title = "title";
-		columnMap.description = "content";
-		columnMap.pubDate = "createddate";
-		columnMap.link = "link";
-		columnMap.author = "rssAuthor";
-		columnMap.category_tag = "categories";
+    /**
+     * Build comment feeds according to filtering elements
+     *
+     * @slug        The content slug to filter on
+     * @contentType The content type discriminator to filter on
+     * @siteID      The site to filter on
+     */
+    private function buildCommentFeed(string slug = '', string contentType = '', string siteID = '') {
+        var settings = variables.settingService.getAllSettings();
+        var commentResults = variables.commentService.findAllApproved(
+            contentID = variables.contentService.getIDBySlug(arguments.slug),
+            contentType = arguments.contentType,
+            max = settings.cb_rss_maxComments,
+            siteID = arguments.siteID
+        );
+        var myArray = [];
+        var feedStruct = {};
+        var columnMap = {};
+        var qComments = entityToQuery(commentResults.comments);
 
-		// Add necessary columns to query
-		queryAddColumn(
-			qComments,
-			"title",
-			myArray
-		);
-		queryAddColumn(
-			qComments,
-			"linkComments",
-			myArray
-		);
-		queryAddColumn(
-			qComments,
-			"rssAuthor",
-			myArray
-		);
-		queryAddColumn(
-			qComments,
-			"guid_permalink",
-			myArray
-		);
-		queryAddColumn(
-			qComments,
-			"guid_string",
-			myArray
-		);
+        // Create the column maps
+        columnMap.title = 'title';
+        columnMap.description = 'content';
+        columnMap.pubDate = 'createddate';
+        columnMap.link = 'link';
+        columnMap.author = 'rssAuthor';
+        columnMap.category_tag = 'categories';
 
-		// Attach permalinks
-		for ( var i = 1; i LTE commentResults.count; i++ ) {
-			// build URL to entry
-			qComments.title[ i ] = "Comment by #qComments.author[ i ]# on #commentResults.comments[ i ].getParentTitle()#";
-			qComments.rssAuthor[ i ] = "#qComments.authorEmail# (#qComments.author#)";
-			qComments.linkComments[ i ] = CBHelper.linkComment( commentResults.comments[ i ] );
-			qComments.content[ i ] = cleanupContent( qComments.content[ i ] );
-			qComments.guid_permalink[ i ] = false;
-			qComments.guid_string[ i ] = CBHelper.linkComment( commentResults.comments[ i ] );
-		}
+        // Add necessary columns to query
+        queryAddColumn(qComments, 'title', myArray);
+        queryAddColumn(qComments, 'linkComments', myArray);
+        queryAddColumn(qComments, 'rssAuthor', myArray);
+        queryAddColumn(qComments, 'guid_permalink', myArray);
+        queryAddColumn(qComments, 'guid_string', myArray);
 
-		// Generate feed items
-		feedStruct.title = "Comments " & settings.cb_rss_title;
-		feedStruct.generator = settings.cb_rss_generator;
-		feedStruct.copyright = settings.cb_rss_copyright;
-		feedStruct.description = settings.cb_rss_description;
-		if ( len( settings.cb_rss_webmaster ) ) {
-			feedStruct.webmaster = settings.cb_rss_webmaster;
-		}
-		feedStruct.pubDate = now();
-		feedStruct.lastbuilddate = now();
-		feedStruct.link = CBHelper.linkHome();
-		feedStruct.items = qComments;
+        // Attach permalinks
+        for (var i = 1; i LTE commentResults.count; i++) {
+            // build URL to entry
+            qComments.title[i] = 'Comment by #qComments.author[i]# on #commentResults.comments[i].getParentTitle()#';
+            qComments.rssAuthor[i] = '#qComments.authorEmail# (#qComments.author#)';
+            qComments.linkComments[i] = CBHelper.linkComment(commentResults.comments[i]);
+            qComments.content[i] = cleanupContent(qComments.content[i]);
+            qComments.guid_permalink[i] = false;
+            qComments.guid_string[i] = CBHelper.linkComment(commentResults.comments[i]);
+        }
 
-		return variables.feedGenerator.createFeed( feedStruct, columnMap );
-	}
+        // Generate feed items
+        feedStruct.title = 'Comments ' & settings.cb_rss_title;
+        feedStruct.generator = settings.cb_rss_generator;
+        feedStruct.copyright = settings.cb_rss_copyright;
+        feedStruct.description = settings.cb_rss_description;
+        if (len(settings.cb_rss_webmaster)) {
+            feedStruct.webmaster = settings.cb_rss_webmaster;
+        }
+        feedStruct.pubDate = now();
+        feedStruct.lastbuilddate = now();
+        feedStruct.link = CBHelper.linkHome();
+        feedStruct.items = qComments;
 
-	/**
-	 * Cleanup HTML to normal strings to avoid parsing issues
-	 */
-	private function cleanupContent( required content ) {
-		return reReplaceNoCase(
-			arguments.content,
-			"<[^>]*>",
-			"",
-			"all"
-		);
-	}
+        return variables.feedGenerator.createFeed(feedStruct, columnMap);
+    }
+
+    /**
+     * Cleanup HTML to normal strings to avoid parsing issues
+     */
+    private function cleanupContent(required content) {
+        return reReplaceNoCase(
+            arguments.content,
+            '<[^>]*>',
+            '',
+            'all'
+        );
+    }
 
 }


### PR DESCRIPTION
# Description

RSS Feed Slug Column Error Fix

Issue
Runtime error encountered when generating RSS feeds for blog entries and pages:

`Column 'SLUG' does not exist in query`

Error occurred at RSSService.cfc during entry feed generation and similar line in page feed builder.

Root Cause
The `buildEntryFeed()` and `buildPageFeed()` methods were attempting to access a `slug` column from query objects created by `entityToQuery(entryResults.content)` and `entityToQuery(pageResults.content)`. However, `entityToQuery()` does not include all entity properties as query columns by default, and the `slug` property was absent from the resulting query, triggering a column-not-found exception on BoxLang runtime.

Solution
Replaced query column access with entity object getters in both feed builders:

**Entry feed RSSService.cfc**: Extract slug via `entryResults.content[i].getSlug()` instead of `qEntries.slug[i]`
**Page feed RSSService.cfc**: Extract slug via `pageResults.content[i].getSlug()` instead of `qPages.slug`

## Type of change

- [x] Bug Fix
- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)